### PR TITLE
fix: analytics-api のヘルスチェック改善と入力バリデーション強化

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import dataclass, field
 
 from fastapi import FastAPI
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -20,6 +20,13 @@ class MetricPayload(BaseModel):
     status: str
     response_time_ms: float
     timestamp: float | None = None
+
+    @field_validator("response_time_ms")
+    @classmethod
+    def validate_response_time(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("response_time_ms must be non-negative")
+        return v
 
 
 @dataclass
@@ -73,7 +80,7 @@ store = MetricsStore()
 @app.get("/health")
 def health():
     logger.debug("Health check requested")
-    return {"status": "healthy", "service": "analytics-api"}
+    return {"status": "healthy", "service": "analytics-api", "timestamp": time.time()}
 
 
 @app.post("/metrics", status_code=201)

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -18,6 +18,8 @@ def test_health():
     data = resp.json()
     assert data["status"] == "healthy"
     assert data["service"] == "analytics-api"
+    assert "timestamp" in data
+    assert isinstance(data["timestamp"], float)
 
 
 def test_post_metric():
@@ -27,6 +29,18 @@ def test_post_metric():
     data = resp.json()
     assert data["recorded"] is True
     assert data["service"] == "web"
+
+
+def test_post_metric_negative_response_time():
+    payload = {"service": "web", "status": "healthy", "response_time_ms": -10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_zero_response_time():
+    payload = {"service": "web", "status": "healthy", "response_time_ms": 0.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 201
 
 
 def test_get_metrics_empty():


### PR DESCRIPTION
## 変更概要
- `/health` エンドポイントのレスポンスに `timestamp` フィールドを追加
- `POST /metrics` で `response_time_ms` が負の値の場合に 422 エラーを返すバリデーションを追加
- Pydantic `field_validator` を使用した宣言的なバリデーション

## テスト
- `test_health`: タイムスタンプの型確認を追加
- `test_post_metric_negative_response_time`: 負値で 422 を確認
- `test_post_metric_zero_response_time`: 0 は許可されることを確認

## 動作確認手順
```bash
cd analytics-api && pip install -r requirements.txt && pytest -v
```

Closes #5