### PR TITLE
feat: MetricsStore にレコード上限と古いデータの自動削除を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -14,6 +14,8 @@ logger = logging.getLogger("analytics-api")
 
 app = FastAPI(title="PulseBoard Analytics API", version="1.0.0")
 
+MAX_RECORDS = int(os.getenv("MAX_RECORDS", "10000"))
+
 
 class MetricPayload(BaseModel):
     service: str
@@ -40,9 +42,14 @@ class MetricRecord:
 @dataclass
 class MetricsStore:
     records: list[MetricRecord] = field(default_factory=list)
+    max_records: int = MAX_RECORDS
 
     def add(self, record: MetricRecord) -> MetricRecord:
         self.records.append(record)
+        if len(self.records) > self.max_records:
+            removed = len(self.records) - self.max_records
+            del self.records[:removed]
+            logger.info("Evicted %d old records (store capped at %d)", removed, self.max_records)
         logger.info("Recorded metric for service=%s status=%s", record.service, record.status)
         return record
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2,7 +2,7 @@ import time
 
 from fastapi.testclient import TestClient
 
-from main import MetricsStore, app, store
+from main import MetricRecord, MetricsStore, app, store
 
 
 client = TestClient(app)
@@ -74,9 +74,45 @@ def test_summary():
 
 def test_metrics_store_unit():
     s = MetricsStore()
-    s.add(s.__class__.__dataclass_fields__ and __import__("main").MetricRecord(
+    s.add(MetricRecord(
         service="x", status="healthy", response_time_ms=5, timestamp=time.time()
     ))
     assert len(s.get_all()) == 1
     assert len(s.get_by_service("x")) == 1
     assert len(s.get_by_service("y")) == 0
+
+
+def test_metrics_store_max_capacity():
+    s = MetricsStore(max_records=3)
+    for i in range(5):
+        s.add(MetricRecord(
+            service=f"svc-{i}", status="healthy", response_time_ms=10.0, timestamp=time.time()
+        ))
+    assert len(s.get_all()) == 3
+    services = [r.service for r in s.get_all()]
+    assert "svc-0" not in services
+    assert "svc-1" not in services
+    assert "svc-4" in services
+
+
+def test_metrics_store_eviction_preserves_order():
+    s = MetricsStore(max_records=2)
+    for i in range(4):
+        s.add(MetricRecord(
+            service=f"s{i}", status="healthy", response_time_ms=float(i), timestamp=time.time()
+        ))
+    records = s.get_all()
+    assert len(records) == 2
+    assert records[0].service == "s2"
+    assert records[1].service == "s3"
+
+
+def test_metrics_store_at_exact_capacity():
+    s = MetricsStore(max_records=3)
+    for i in range(3):
+        s.add(MetricRecord(
+            service=f"svc-{i}", status="healthy", response_time_ms=10.0, timestamp=time.time()
+        ))
+    assert len(s.get_all()) == 3
+    services = [r.service for r in s.get_all()]
+    assert services == ["svc-0", "svc-1", "svc-2"]


### PR DESCRIPTION
## 変更概要

- `MetricsStore` に `max_records` パラメータを追加（デフォルト: 10000）
- `MAX_RECORDS` 環境変数で上限を設定可能
- 上限超過時は古いレコードから自動的に削除（FIFO）
- 削除時にログ出力で通知
- レコード上限関連テスト3件を追加

Closes #7

## 動作確認手順

1. `cd analytics-api && pip install -r requirements.txt`
2. `pytest -v` で全テストがパスすることを確認