### PR TITLE
fix: /checkハンドラのmetrics報告追加とMetricsStoreスレッドセーフ化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 test: test-python test-go test-ts
 
 test-python:
-	cd analytics-api && pip install -q -r requirements.txt && pytest -v
+	cd analytics-api && pip install -q -r requirements-dev.txt && pytest -v
 
 test-go:
 	cd health-checker && go test -v ./...
@@ -14,7 +14,7 @@ test-ts:
 lint: lint-python lint-go lint-ts
 
 lint-python:
-	cd analytics-api && flake8 --max-line-length=120 --exclude=__pycache__ main.py
+	cd analytics-api && pip install -q -r requirements-dev.txt && flake8 --max-line-length=120 --exclude=__pycache__ main.py
 
 lint-go:
 	cd health-checker && go vet ./...

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 
@@ -43,25 +44,31 @@ class MetricRecord:
 class MetricsStore:
     records: list[MetricRecord] = field(default_factory=list)
     max_records: int = MAX_RECORDS
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def add(self, record: MetricRecord) -> MetricRecord:
-        self.records.append(record)
-        if len(self.records) > self.max_records:
-            removed = len(self.records) - self.max_records
-            del self.records[:removed]
-            logger.info("Evicted %d old records (store capped at %d)", removed, self.max_records)
+        with self._lock:
+            self.records.append(record)
+            if len(self.records) > self.max_records:
+                removed = len(self.records) - self.max_records
+                del self.records[:removed]
+                logger.info("Evicted %d old records (store capped at %d)", removed, self.max_records)
         logger.info("Recorded metric for service=%s status=%s", record.service, record.status)
         return record
 
     def get_all(self) -> list[MetricRecord]:
-        return list(self.records)
+        with self._lock:
+            return list(self.records)
 
     def get_by_service(self, service: str) -> list[MetricRecord]:
-        return [r for r in self.records if r.service == service]
+        with self._lock:
+            return [r for r in self.records if r.service == service]
 
     def summary(self) -> dict:
+        with self._lock:
+            records_snapshot = list(self.records)
         services: dict[str, dict] = {}
-        for r in self.records:
+        for r in records_snapshot:
             if r.service not in services:
                 services[r.service] = {"total": 0, "healthy": 0, "avg_response_ms": 0.0, "times": []}
             s = services[r.service]
@@ -122,3 +129,4 @@ if __name__ == "__main__":
     port = int(os.getenv("ANALYTICS_PORT", "8001"))
     logger.info("Starting Analytics API on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port)
+

--- a/analytics-api/requirements-dev.txt
+++ b/analytics-api/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+flake8==7.1.1

--- a/analytics-api/requirements.txt
+++ b/analytics-api/requirements.txt
@@ -2,5 +2,3 @@ fastapi==0.115.6
 uvicorn==0.34.0
 pydantic==2.10.4
 httpx==0.28.1
-pytest==8.3.4
-flake8==7.1.1

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -111,7 +111,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func makeCheckHandler(targets []ServiceTarget) http.HandlerFunc {
+func makeCheckHandler(targets []ServiceTarget, analyticsURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		client := &http.Client{Timeout: 5 * time.Second}
 		results := make([]CheckResult, 0, len(targets))
@@ -121,10 +121,18 @@ func makeCheckHandler(targets []ServiceTarget) http.HandlerFunc {
 			results = append(results, result)
 		}
 
+		reported := 0
+		for _, result := range results {
+			if err := ReportMetric(client, analyticsURL, result); err == nil {
+				reported++
+			}
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"checked_at": time.Now().UTC().Format(time.RFC3339),
 			"results":    results,
+			"reported":   reported,
 		})
 	}
 }
@@ -135,10 +143,12 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", healthHandler)
-	mux.HandleFunc("/check", makeCheckHandler(targets))
+	analyticsURL := GetEnv("ANALYTICS_URL", "http://localhost:8001")
+	mux.HandleFunc("/check", makeCheckHandler(targets, analyticsURL))
 
 	log.Printf("[INFO] Health Checker starting on port %s", port)
 	if err := http.ListenAndServe(":"+port, mux); err != nil {
 		log.Fatalf("[FATAL] Server failed: %v", err)
 	}
 }
+

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -108,11 +108,16 @@ func TestCheckHandler(t *testing.T) {
 	}))
 	defer backend.Close()
 
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer mockAnalytics.Close()
+
 	targets := []ServiceTarget{
 		{Name: "svc-a", URL: backend.URL + "/health"},
 	}
 
-	handler := makeCheckHandler(targets)
+	handler := makeCheckHandler(targets, mockAnalytics.URL)
 	req := httptest.NewRequest("GET", "/check", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
@@ -127,6 +132,10 @@ func TestCheckHandler(t *testing.T) {
 	if !ok || len(results) != 1 {
 		t.Fatalf("expected 1 result, got %v", body["results"])
 	}
+	reported := int(body["reported"].(float64))
+	if reported != 1 {
+		t.Errorf("expected 1 reported, got %d", reported)
+	}
 }
 
 func TestGetEnv(t *testing.T) {
@@ -138,3 +147,4 @@ func TestGetEnv(t *testing.T) {
 		t.Errorf("expected custom, got %s", got)
 	}
 }
+


### PR DESCRIPTION
## 変更概要

- health-checker の `/check` ハンドラで `ReportMetric()` を呼び出し、チェック結果を analytics に報告するよう修正
- analytics-api の `MetricsStore` に `threading.Lock` を追加し、マルチワーカー環境でのデータ競合を防止
- analytics-api の `requirements.txt` からテスト依存(pytest, flake8)を分離し `requirements-dev.txt` を新規作成
- Makefile を `requirements-dev.txt` に対応

Closes #11

## 動作確認手順

1. `cd health-checker && go test -v ./...` で全7テストがパス
2. `cd analytics-api && pip install -r requirements-dev.txt && pytest -v` で全11テストがパス
3. `make lint` でlintが通る