### PR TITLE
test: health-checkerとanalytics-apiのテストカバレッジ向上

### DIFF
--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -116,3 +116,35 @@ def test_metrics_store_at_exact_capacity():
     assert len(s.get_all()) == 3
     services = [r.service for r in s.get_all()]
     assert services == ["svc-0", "svc-1", "svc-2"]
+
+
+def test_post_metric_missing_required_fields():
+    resp = client.post("/metrics", json={})
+    assert resp.status_code == 422
+
+
+def test_post_metric_explicit_timestamp():
+    payload = {
+        "service": "web",
+        "status": "healthy",
+        "response_time_ms": 10.0,
+        "timestamp": 1700000000.0,
+    }
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["timestamp"] == 1700000000.0
+
+
+def test_summary_empty_store():
+    resp = client.get("/metrics/summary")
+    assert resp.status_code == 200
+    assert resp.json() == {}
+
+
+def test_get_metrics_unknown_service():
+    resp = client.get("/metrics?service=nonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 0
+    assert data["metrics"] == []

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -148,3 +148,90 @@ func TestGetEnv(t *testing.T) {
 	}
 }
 
+func TestReportMetricFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	result := CheckResult{Service: "test", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1234567890}
+	err := ReportMetric(client, server.URL, result)
+	if err == nil {
+		t.Fatal("expected error for non-201 response, got nil")
+	}
+}
+
+func TestCheckHandler_ReportingFails(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	}))
+	defer backend.Close()
+
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockAnalytics.Close()
+
+	targets := []ServiceTarget{
+		{Name: "svc-a", URL: backend.URL + "/health"},
+	}
+
+	handler := makeCheckHandler(targets, mockAnalytics.URL)
+	req := httptest.NewRequest("GET", "/check", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	reported := int(body["reported"].(float64))
+	if reported != 0 {
+		t.Errorf("expected 0 reported when analytics fails, got %d", reported)
+	}
+}
+
+func TestCheckHandler_MultipleTargets(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	}))
+	defer healthy.Close()
+
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer unhealthy.Close()
+
+	mockAnalytics := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer mockAnalytics.Close()
+
+	targets := []ServiceTarget{
+		{Name: "svc-ok", URL: healthy.URL + "/health"},
+		{Name: "svc-bad", URL: unhealthy.URL + "/health"},
+	}
+
+	handler := makeCheckHandler(targets, mockAnalytics.URL)
+	req := httptest.NewRequest("GET", "/check", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	results := body["results"].([]interface{})
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	reported := int(body["reported"].(float64))
+	if reported != 2 {
+		t.Errorf("expected 2 reported, got %d", reported)
+	}
+}
+


### PR DESCRIPTION
## 変更概要

### health-checker (Go)
- `TestReportMetricFailure`: analytics APIが500を返した場合のエラー検証
- `TestCheckHandler_ReportingFails`: 報告失敗時の `reported=0` 検証
- `TestCheckHandler_MultipleTargets`: 複数ターゲット（healthy+unhealthy混在）での動作検証

### analytics-api (Python)
- `test_post_metric_missing_required_fields`: 必須フィールド欠落時の422検証
- `test_post_metric_explicit_timestamp`: timestamp明示指定時のパススルー検証
- `test_summary_empty_store`: 空ストアでの空dict返却検証
- `test_get_metrics_unknown_service`: 未知サービス指定時の空結果検証

Closes #13

## 動作確認手順

1. `cd health-checker && go test -v ./...` — 全10テストパス
2. `cd analytics-api && pytest -v` — 全15テストパス