### PR TITLE
feat: analytics-apiにDELETE /metricsエンドポイントとhealth-checkerにgraceful shutdownを追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -4,7 +4,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Query
 from pydantic import BaseModel, field_validator
 
 logging.basicConfig(
@@ -64,6 +64,15 @@ class MetricsStore:
         with self._lock:
             return [r for r in self.records if r.service == service]
 
+    def delete_by_service(self, service: str) -> int:
+        with self._lock:
+            before = len(self.records)
+            self.records = [r for r in self.records if r.service != service]
+            deleted = before - len(self.records)
+        if deleted > 0:
+            logger.info("Deleted %d records for service=%s", deleted, service)
+        return deleted
+
     def summary(self) -> dict:
         with self._lock:
             records_snapshot = list(self.records)
@@ -118,6 +127,14 @@ def get_metrics(service: str | None = None):
     return {"count": len(records), "metrics": [r.__dict__ for r in records]}
 
 
+@app.delete("/metrics")
+def delete_metrics(service: str = Query(..., description="削除対象のサービス名")):
+    deleted = store.delete_by_service(service)
+    if deleted == 0:
+        return {"error": "No metrics found for the specified service", "deleted_count": 0}
+    return {"message": "Metrics deleted", "service": service, "deleted_count": deleted}
+
+
 @app.get("/metrics/summary")
 def get_summary():
     return store.summary()
@@ -129,4 +146,3 @@ if __name__ == "__main__":
     port = int(os.getenv("ANALYTICS_PORT", "8001"))
     logger.info("Starting Analytics API on port %d", port)
     uvicorn.run(app, host="0.0.0.0", port=port)
-

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -148,3 +148,63 @@ def test_get_metrics_unknown_service():
     data = resp.json()
     assert data["count"] == 0
     assert data["metrics"] == []
+
+
+def test_delete_metrics_success():
+    client.post("/metrics", json={"service": "to_delete", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "to_delete", "status": "unhealthy", "response_time_ms": 20})
+    client.post("/metrics", json={"service": "keep", "status": "healthy", "response_time_ms": 30})
+
+    resp = client.delete("/metrics?service=to_delete")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["message"] == "Metrics deleted"
+    assert data["deleted_count"] == 2
+    assert data["service"] == "to_delete"
+
+    remaining = client.get("/metrics").json()
+    assert remaining["count"] == 1
+    assert remaining["metrics"][0]["service"] == "keep"
+
+
+def test_delete_metrics_not_found():
+    resp = client.delete("/metrics?service=nonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_count"] == 0
+
+
+def test_delete_metrics_missing_param():
+    resp = client.delete("/metrics")
+    assert resp.status_code == 422
+
+
+def test_delete_metrics_updates_summary():
+    client.post("/metrics", json={"service": "svc_a", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "svc_b", "status": "healthy", "response_time_ms": 20})
+
+    client.delete("/metrics?service=svc_a")
+
+    summary = client.get("/metrics/summary").json()
+    assert "svc_a" not in summary
+    assert "svc_b" in summary
+
+
+def test_metrics_store_delete_by_service_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=time.time()))
+    s.add(MetricRecord(service="b", status="healthy", response_time_ms=20, timestamp=time.time()))
+    s.add(MetricRecord(service="a", status="unhealthy", response_time_ms=30, timestamp=time.time()))
+
+    deleted = s.delete_by_service("a")
+    assert deleted == 2
+    assert len(s.get_all()) == 1
+    assert s.get_all()[0].service == "b"
+
+
+def test_metrics_store_delete_nonexistent():
+    s = MetricsStore()
+    s.add(MetricRecord(service="x", status="healthy", response_time_ms=5, timestamp=time.time()))
+    deleted = s.delete_by_service("y")
+    assert deleted == 0
+    assert len(s.get_all()) == 1

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -146,9 +150,37 @@ func main() {
 	analyticsURL := GetEnv("ANALYTICS_URL", "http://localhost:8001")
 	mux.HandleFunc("/check", makeCheckHandler(targets, analyticsURL))
 
-	log.Printf("[INFO] Health Checker starting on port %s", port)
-	if err := http.ListenAndServe(":"+port, mux); err != nil {
-		log.Fatalf("[FATAL] Server failed: %v", err)
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: mux,
 	}
-}
 
+	shutdownTimeout := 30 * time.Second
+	if v := os.Getenv("SHUTDOWN_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			shutdownTimeout = time.Duration(n) * time.Second
+		}
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Printf("[INFO] Health Checker starting on port %s", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("[FATAL] Server failed: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	stop()
+	log.Printf("[INFO] Shutting down gracefully...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("[FATAL] Forced shutdown: %v", err)
+	}
+	log.Println("[INFO] Server stopped")
+}


### PR DESCRIPTION
## 変更概要
- **analytics-api**: `DELETE /metrics?service=xxx` エンドポイントを追加。MetricsStoreに`delete_by_service`メソッドを追加し、指定サービスのメトリクスを一括削除可能に
- **health-checker (Go)**: `signal.NotifyContext`を使ったgraceful shutdownを実装。`SHUTDOWN_TIMEOUT_SECONDS`環境変数で設定可能
- テスト6件追加（DELETE成功・未発見・パラメータ不足・サマリー更新・ユニットテスト2件）

Closes #15

## 動作確認
- `flake8 --max-line-length=120 main.py` → PASS
- `pytest -v test_main.py` → 21 passed
- `go vet ./...` → OK
- `go test -v ./...` → 10 passed