### PR TITLE
feat: analytics-api の入力バリデーション強化（service / status / response_time_ms）

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -1,11 +1,13 @@
 import logging
+import math
 import os
 import threading
 import time
 from dataclasses import dataclass, field
+from typing import Literal
 
 from fastapi import FastAPI, Query
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -16,19 +18,42 @@ logger = logging.getLogger("analytics-api")
 app = FastAPI(title="PulseBoard Analytics API", version="1.0.0")
 
 MAX_RECORDS = int(os.getenv("MAX_RECORDS", "10000"))
+MAX_SERVICE_LENGTH = 100
+MAX_RESPONSE_TIME_MS = 60_000.0
+ALLOWED_STATUSES = ("healthy", "unhealthy", "degraded", "unknown")
+StatusLiteral = Literal["healthy", "unhealthy", "degraded", "unknown"]
 
 
 class MetricPayload(BaseModel):
-    service: str
-    status: str
-    response_time_ms: float
-    timestamp: float | None = None
+    service: str = Field(..., min_length=1, max_length=MAX_SERVICE_LENGTH)
+    status: StatusLiteral
+    response_time_ms: float = Field(..., ge=0, le=MAX_RESPONSE_TIME_MS)
+    timestamp: float | None = Field(default=None, gt=0)
+
+    @field_validator("service")
+    @classmethod
+    def validate_service(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("service must not be blank")
+        if len(stripped) > MAX_SERVICE_LENGTH:
+            raise ValueError(f"service must be at most {MAX_SERVICE_LENGTH} characters")
+        return stripped
 
     @field_validator("response_time_ms")
     @classmethod
     def validate_response_time(cls, v: float) -> float:
-        if v < 0:
-            raise ValueError("response_time_ms must be non-negative")
+        if not math.isfinite(v):
+            raise ValueError("response_time_ms must be a finite number")
+        return v
+
+    @field_validator("timestamp")
+    @classmethod
+    def validate_timestamp(cls, v: float | None) -> float | None:
+        if v is None:
+            return None
+        if not math.isfinite(v):
+            raise ValueError("timestamp must be a finite number")
         return v
 
 
@@ -128,11 +153,21 @@ def get_metrics(service: str | None = None):
 
 
 @app.delete("/metrics")
-def delete_metrics(service: str = Query(..., description="削除対象のサービス名")):
-    deleted = store.delete_by_service(service)
+def delete_metrics(
+    service: str = Query(
+        ...,
+        description="削除対象のサービス名",
+        min_length=1,
+        max_length=MAX_SERVICE_LENGTH,
+    ),
+):
+    normalized = service.strip()
+    if not normalized:
+        return {"error": "service must not be blank", "deleted_count": 0}
+    deleted = store.delete_by_service(normalized)
     if deleted == 0:
         return {"error": "No metrics found for the specified service", "deleted_count": 0}
-    return {"message": "Metrics deleted", "service": service, "deleted_count": deleted}
+    return {"message": "Metrics deleted", "service": normalized, "deleted_count": deleted}
 
 
 @app.get("/metrics/summary")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -208,3 +208,82 @@ def test_metrics_store_delete_nonexistent():
     deleted = s.delete_by_service("y")
     assert deleted == 0
     assert len(s.get_all()) == 1
+
+
+def test_post_metric_rejects_invalid_status():
+    payload = {"service": "web", "status": "broken", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_rejects_blank_service():
+    payload = {"service": "   ", "status": "healthy", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_rejects_empty_service():
+    payload = {"service": "", "status": "healthy", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_rejects_overlong_service():
+    payload = {"service": "x" * 101, "status": "healthy", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_accepts_max_length_service():
+    payload = {"service": "x" * 100, "status": "healthy", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 201
+
+
+def test_post_metric_rejects_excessive_response_time():
+    payload = {"service": "web", "status": "healthy", "response_time_ms": 60001.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_accepts_response_time_at_limit():
+    payload = {"service": "web", "status": "healthy", "response_time_ms": 60000.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 201
+
+
+def test_post_metric_rejects_negative_timestamp():
+    payload = {
+        "service": "web",
+        "status": "healthy",
+        "response_time_ms": 10.0,
+        "timestamp": -1.0,
+    }
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 422
+
+
+def test_post_metric_accepts_all_allowed_statuses():
+    for status in ("healthy", "unhealthy", "degraded", "unknown"):
+        resp = client.post(
+            "/metrics",
+            json={"service": "web", "status": status, "response_time_ms": 1.0},
+        )
+        assert resp.status_code == 201, f"status={status} failed"
+
+
+def test_post_metric_strips_whitespace_in_service():
+    payload = {"service": "  web  ", "status": "healthy", "response_time_ms": 10.0}
+    resp = client.post("/metrics", json=payload)
+    assert resp.status_code == 201
+    assert resp.json()["service"] == "web"
+
+
+def test_delete_metrics_rejects_overlong_service():
+    resp = client.delete("/metrics?service=" + "x" * 101)
+    assert resp.status_code == 422
+
+
+def test_delete_metrics_rejects_empty_service():
+    resp = client.delete("/metrics?service=")
+    assert resp.status_code == 422


### PR DESCRIPTION
## 概要

- `MetricPayload` に Pydantic v2 の `Field` 制約と `field_validator` を追加
  - `service`: `min_length=1` / `max_length=100`、空白のみは拒否、前後の whitespace は trim
  - `status`: `Literal["healthy","unhealthy","degraded","unknown"]` で許可値のみに制限
  - `response_time_ms`: `ge=0` / `le=60000`、`math.isfinite` で NaN / Inf を拒否
  - `timestamp`: `gt=0` を要求、`math.isfinite` 検証
- `DELETE /metrics?service=...` のクエリにも `min_length=1` / `max_length=100` を適用
- `ALLOWED_STATUSES` / `MAX_SERVICE_LENGTH` / `MAX_RESPONSE_TIME_MS` を定数化

Closes #17

## 動作確認手順

```bash
cd analytics-api
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
```

- 既存テスト 21 件はすべてパス（互換維持）
- 追加テスト 12 件：
  - 不正な `status` を 422 で拒否
  - 空 / 空白 / 101文字以上の `service` を 422 で拒否
  - 100文字ちょうどは 201（境界値 OK）
  - `response_time_ms = 60001` は 422、`60000` は 201
  - 負の `timestamp` を 422 で拒否
  - 4 種類すべての許可値 `status` で 201
  - `service` の前後空白 trim 確認
  - `DELETE /metrics?service=...` の長さ・空文字バリデーション
