### PR TITLE
feat: analytics-api GET /metrics に時系列フィルタ since/until を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Response:
 |--------|----------|-------------|
 | GET | `/health` | Health check |
 | POST | `/metrics` | Record a health check metric |
-| GET | `/metrics` | List metrics (`?service=`, `?limit=`, `?offset=`） |
+| GET | `/metrics` | List metrics (`?service=`, `?since=`, `?until=`, `?limit=`, `?offset=`） |
 | DELETE | `/metrics?service=` | サービス名指定で対象メトリクスを削除 |
 | GET | `/metrics/summary` | Per-service summary statistics |
 
@@ -149,7 +149,15 @@ curl "http://localhost:8001/metrics?limit=20&offset=40"
 
 # サービス絞り込み + ページネーション
 curl "http://localhost:8001/metrics?service=web&limit=10"
+
+# 時刻範囲指定（Unix timestamp、since 以降 / until 以前）
+curl "http://localhost:8001/metrics?since=1700000000&until=1700003600"
+
+# 時刻範囲 + サービス絞り込みの組合せ
+curl "http://localhost:8001/metrics?service=web&since=1700000000"
 ```
+
+`since > until` の場合は 400、負値・非有限値は 422 で拒否される。
 
 レスポンス:
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Literal
 
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
 logging.basicConfig(
@@ -91,6 +91,22 @@ class MetricsStore:
         with self._lock:
             return [r for r in self.records if r.service == service]
 
+    def filter(
+        self,
+        service: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[MetricRecord]:
+        with self._lock:
+            results = list(self.records)
+        if service is not None:
+            results = [r for r in results if r.service == service]
+        if since is not None:
+            results = [r for r in results if r.timestamp >= since]
+        if until is not None:
+            results = [r for r in results if r.timestamp <= until]
+        return results
+
     def delete_by_service(self, service: str) -> int:
         with self._lock:
             before = len(self.records)
@@ -148,6 +164,16 @@ def post_metric(payload: MetricPayload):
 @app.get("/metrics")
 def get_metrics(
     service: str | None = None,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）のレコードに絞り込む",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）のレコードに絞り込む",
+    ),
     limit: int = Query(
         default=METRICS_DEFAULT_LIMIT,
         ge=1,
@@ -160,10 +186,17 @@ def get_metrics(
         description="先頭から読み飛ばす件数",
     ),
 ):
-    if service:
-        records = store.get_by_service(service)
-    else:
-        records = store.get_all()
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    records = store.filter(service=service, since=since, until=until)
     total = len(records)
     page = records[offset:offset + limit]
     return {

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -127,6 +127,70 @@ def test_get_metrics_filter_then_paginate():
     assert services == {"target"}
 
 
+def test_get_metrics_filter_since():
+    client.post("/metrics", json={"service": "old", "status": "healthy", "response_time_ms": 1, "timestamp": 1000.0})
+    client.post("/metrics", json={"service": "mid", "status": "healthy", "response_time_ms": 1, "timestamp": 2000.0})
+    client.post("/metrics", json={"service": "new", "status": "healthy", "response_time_ms": 1, "timestamp": 3000.0})
+    resp = client.get("/metrics?since=2000")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    services = {m["service"] for m in data["metrics"]}
+    assert services == {"mid", "new"}
+
+
+def test_get_metrics_filter_until():
+    client.post("/metrics", json={"service": "old", "status": "healthy", "response_time_ms": 1, "timestamp": 1000.0})
+    client.post("/metrics", json={"service": "mid", "status": "healthy", "response_time_ms": 1, "timestamp": 2000.0})
+    client.post("/metrics", json={"service": "new", "status": "healthy", "response_time_ms": 1, "timestamp": 3000.0})
+    resp = client.get("/metrics?until=2000")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    services = {m["service"] for m in data["metrics"]}
+    assert services == {"old", "mid"}
+
+
+def test_get_metrics_filter_since_and_until():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 1, "timestamp": 1000.0})
+    client.post("/metrics", json={"service": "b", "status": "healthy", "response_time_ms": 1, "timestamp": 2000.0})
+    client.post("/metrics", json={"service": "c", "status": "healthy", "response_time_ms": 1, "timestamp": 3000.0})
+    client.post("/metrics", json={"service": "d", "status": "healthy", "response_time_ms": 1, "timestamp": 4000.0})
+    resp = client.get("/metrics?since=1500&until=3500")
+    assert resp.status_code == 200
+    data = resp.json()
+    services = {m["service"] for m in data["metrics"]}
+    assert services == {"b", "c"}
+
+
+def test_get_metrics_filter_since_combined_with_service():
+    client.post("/metrics", json={"service": "x", "status": "healthy", "response_time_ms": 1, "timestamp": 1000.0})
+    client.post("/metrics", json={"service": "x", "status": "healthy", "response_time_ms": 1, "timestamp": 5000.0})
+    client.post("/metrics", json={"service": "y", "status": "healthy", "response_time_ms": 1, "timestamp": 5000.0})
+    resp = client.get("/metrics?service=x&since=2000")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["metrics"][0]["service"] == "x"
+    assert data["metrics"][0]["timestamp"] == 5000.0
+
+
+def test_get_metrics_rejects_since_greater_than_until():
+    resp = client.get("/metrics?since=3000&until=1000")
+    assert resp.status_code == 400
+    assert "since" in resp.json()["detail"].lower()
+
+
+def test_get_metrics_rejects_negative_since():
+    resp = client.get("/metrics?since=-1")
+    assert resp.status_code == 422
+
+
+def test_get_metrics_rejects_negative_until():
+    resp = client.get("/metrics?until=-1")
+    assert resp.status_code == 422
+
+
 def test_summary():
     client.post("/metrics", json={"service": "svc1", "status": "healthy", "response_time_ms": 20})
     client.post("/metrics", json={"service": "svc1", "status": "healthy", "response_time_ms": 30})

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -28,6 +28,8 @@ app.get("/api/metrics", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();
     if (req.query.service) params.set("service", String(req.query.service));
+    if (req.query.since !== undefined) params.set("since", String(req.query.since));
+    if (req.query.until !== undefined) params.set("until", String(req.query.until));
     if (req.query.limit !== undefined) params.set("limit", String(req.query.limit));
     if (req.query.offset !== undefined) params.set("offset", String(req.query.offset));
     const qs = params.toString();


### PR DESCRIPTION
## 変更概要

- `analytics-api/main.py`:
  - `MetricsStore.filter()` を追加（service / since / until を AND で適用）
  - `GET /metrics` に `since` / `until` (Unix timestamp、`ge=0`) クエリを追加
  - `since > until` で 400、`-1` などは 422、非有限値は 400 で拒否
  - 既存の `service` / `limit` / `offset` と組み合わせ可能
- `analytics-api/test_main.py`: 7 ケース追加（since 単独 / until 単独 / 両方 / service 併用 / 反転 / 負値 since / 負値 until）
- `api-gateway/src/app.ts`: `since` / `until` を analytics に forward
- `README.md`: API リファレンスのテーブルとサンプルを更新

## 対応 Issue

Closes #21

## 動作確認

- [x] `pip install -r requirements-dev.txt && flake8 --max-line-length=120 --exclude=__pycache__ main.py` クリーン
- [x] `pytest -v` 47 件 pass（既存 40 件 + 新規 7 件）
- [x] `npm run lint` クリーン（api-gateway）
- [x] `npm test` 7 件 pass（api-gateway）
- [x] `npx tsc --noEmit` クリーン
- [x] `go vet ./... && go test ./...` health-checker pass（影響なし確認）

## 動作例

```bash
# 直近1時間のメトリクスを取得
curl "http://localhost:8001/metrics?since=$(date +%s -d '1 hour ago')"

# 特定サービスの時間帯指定
curl "http://localhost:8001/metrics?service=web&since=1700000000&until=1700003600"

# api-gateway 経由
curl "http://localhost:8000/api/metrics?since=1700000000"

# 反転
curl "http://localhost:8001/metrics?since=3000&until=1000"
# => 400 {"detail":"since must be less than or equal to until"}
```