### PR TITLE
fix: health-checker HTTPサーバーにタイムアウトとメソッド検証を追加（DoS対策）

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `MAX_RECORDS` | `10000` | Analytics API: 保存するメトリクスの最大件数 |
 | `METRICS_DEFAULT_LIMIT` | `100` | Analytics API: `GET /metrics` のデフォルト返却件数 |
 | `METRICS_MAX_LIMIT` | `1000` | Analytics API: `GET /metrics` の `limit` 上限 |
+| `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Health Checker: graceful shutdown 待機時間（秒） |
+| `CHECKER_READ_HEADER_TIMEOUT` | `5` | Health Checker: HTTP リクエストヘッダ読み取りタイムアウト（秒） |
+| `CHECKER_READ_TIMEOUT` | `15` | Health Checker: HTTP リクエスト全体の読み取りタイムアウト（秒） |
+| `CHECKER_WRITE_TIMEOUT` | `15` | Health Checker: HTTP レスポンス書き込みタイムアウト（秒） |
+| `CHECKER_IDLE_TIMEOUT` | `60` | Health Checker: keep-alive アイドルタイムアウト（秒） |
 
 ## Testing
 

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -38,6 +39,28 @@ func GetEnv(key, fallback string) string {
 		return val
 	}
 	return fallback
+}
+
+func envSeconds(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return fallback
+}
+
+func methodAllowed(w http.ResponseWriter, r *http.Request, allowed ...string) bool {
+	for _, m := range allowed {
+		if r.Method == m {
+			return true
+		}
+	}
+	w.Header().Set("Allow", strings.Join(allowed, ", "))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	json.NewEncoder(w).Encode(map[string]string{"error": "method not allowed"})
+	return false
 }
 
 func CheckService(client *http.Client, target ServiceTarget) CheckResult {
@@ -108,6 +131,9 @@ func NewTargets() []ServiceTarget {
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
+	if !methodAllowed(w, r, http.MethodGet, http.MethodHead) {
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(HealthResponse{
 		Status:  "healthy",
@@ -117,6 +143,9 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 
 func makeCheckHandler(targets []ServiceTarget, analyticsURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if !methodAllowed(w, r, http.MethodGet, http.MethodPost) {
+			return
+		}
 		client := &http.Client{Timeout: 5 * time.Second}
 		results := make([]CheckResult, 0, len(targets))
 
@@ -151,16 +180,15 @@ func main() {
 	mux.HandleFunc("/check", makeCheckHandler(targets, analyticsURL))
 
 	srv := &http.Server{
-		Addr:    ":" + port,
-		Handler: mux,
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: envSeconds("CHECKER_READ_HEADER_TIMEOUT", 5*time.Second),
+		ReadTimeout:       envSeconds("CHECKER_READ_TIMEOUT", 15*time.Second),
+		WriteTimeout:      envSeconds("CHECKER_WRITE_TIMEOUT", 15*time.Second),
+		IdleTimeout:       envSeconds("CHECKER_IDLE_TIMEOUT", 60*time.Second),
 	}
 
-	shutdownTimeout := 30 * time.Second
-	if v := os.Getenv("SHUTDOWN_TIMEOUT_SECONDS"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			shutdownTimeout = time.Duration(n) * time.Second
-		}
-	}
+	shutdownTimeout := envSeconds("SHUTDOWN_TIMEOUT_SECONDS", 30*time.Second)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -135,6 +136,70 @@ func TestCheckHandler(t *testing.T) {
 	reported := int(body["reported"].(float64))
 	if reported != 1 {
 		t.Errorf("expected 1 reported, got %d", reported)
+	}
+}
+
+func TestHealthHandler_MethodNotAllowed(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+		req := httptest.NewRequest(method, "/health", nil)
+		w := httptest.NewRecorder()
+		healthHandler(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("method %s: expected 405, got %d", method, w.Code)
+		}
+		allow := w.Header().Get("Allow")
+		if allow == "" {
+			t.Errorf("method %s: expected Allow header to be set", method)
+		}
+	}
+}
+
+func TestHealthHandler_HeadAllowed(t *testing.T) {
+	req := httptest.NewRequest("HEAD", "/health", nil)
+	w := httptest.NewRecorder()
+	healthHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for HEAD, got %d", w.Code)
+	}
+}
+
+func TestCheckHandler_MethodNotAllowed(t *testing.T) {
+	handler := makeCheckHandler(nil, "http://localhost")
+	for _, method := range []string{"PUT", "DELETE", "PATCH"} {
+		req := httptest.NewRequest(method, "/check", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("method %s: expected 405, got %d", method, w.Code)
+		}
+	}
+}
+
+func TestEnvSeconds_Default(t *testing.T) {
+	got := envSeconds("DEFINITELY_NOT_SET_TIMEOUT_VAR", 7*time.Second)
+	if got != 7*time.Second {
+		t.Errorf("expected fallback 7s, got %v", got)
+	}
+}
+
+func TestEnvSeconds_Override(t *testing.T) {
+	t.Setenv("CUSTOM_TIMEOUT_VAR", "12")
+	got := envSeconds("CUSTOM_TIMEOUT_VAR", 5*time.Second)
+	if got != 12*time.Second {
+		t.Errorf("expected 12s, got %v", got)
+	}
+}
+
+func TestEnvSeconds_InvalidFallsBack(t *testing.T) {
+	t.Setenv("BAD_TIMEOUT_VAR", "abc")
+	got := envSeconds("BAD_TIMEOUT_VAR", 4*time.Second)
+	if got != 4*time.Second {
+		t.Errorf("expected 4s fallback for invalid value, got %v", got)
+	}
+	t.Setenv("NEG_TIMEOUT_VAR", "-3")
+	got = envSeconds("NEG_TIMEOUT_VAR", 4*time.Second)
+	if got != 4*time.Second {
+		t.Errorf("expected 4s fallback for negative value, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## 概要

- `health-checker/main.go` の `http.Server` に `ReadHeaderTimeout`(5s) / `ReadTimeout`(15s) / `WriteTimeout`(15s) / `IdleTimeout`(60s) を追加（環境変数で個別上書き可能）
- `methodAllowed` ヘルパーを追加し、`/health` は `GET`/`HEAD`、`/check` は `GET`/`POST` のみ許可。それ以外は `405 Method Not Allowed`（`Allow` ヘッダ付き）
- `SHUTDOWN_TIMEOUT_SECONDS` を `envSeconds` ヘルパーに統一
- `health-checker/main_test.go` に 6 件のテストを追加（メソッド検証、HEAD 許可、`envSeconds` のデフォルト/上書き/不正値）
- `README.md` に Health Checker のタイムアウト環境変数を追記

## 動作確認

- `go vet ./...` エラー無し
- `go test -v ./...` 全 16 件 pass
- Slowloris 攻撃の典型パターン（ヘッダーをゆっくり送る攻撃）を `ReadHeaderTimeout` で緩和

Closes #23