### PR TITLE
feat: GET /metrics に status フィルタを追加（api-gateway 経由含む）

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -94,6 +94,7 @@ class MetricsStore:
     def filter(
         self,
         service: str | None = None,
+        status: str | None = None,
         since: float | None = None,
         until: float | None = None,
     ) -> list[MetricRecord]:
@@ -101,6 +102,8 @@ class MetricsStore:
             results = list(self.records)
         if service is not None:
             results = [r for r in results if r.service == service]
+        if status is not None:
+            results = [r for r in results if r.status == status]
         if since is not None:
             results = [r for r in results if r.timestamp >= since]
         if until is not None:
@@ -164,6 +167,10 @@ def post_metric(payload: MetricPayload):
 @app.get("/metrics")
 def get_metrics(
     service: str | None = None,
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
     since: float | None = Query(
         default=None,
         ge=0,
@@ -196,7 +203,7 @@ def get_metrics(
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
 
-    records = store.filter(service=service, since=since, until=until)
+    records = store.filter(service=service, status=status, since=since, until=until)
     total = len(records)
     page = records[offset:offset + limit]
     return {

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -419,3 +419,41 @@ def test_delete_metrics_rejects_overlong_service():
 def test_delete_metrics_rejects_empty_service():
     resp = client.delete("/metrics?service=")
     assert resp.status_code == 422
+
+
+def test_get_metrics_filters_by_status():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 1})
+    client.post("/metrics", json={"service": "b", "status": "unhealthy", "response_time_ms": 2})
+    client.post("/metrics", json={"service": "c", "status": "degraded", "response_time_ms": 3})
+    resp = client.get("/metrics?status=unhealthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["metrics"][0]["service"] == "b"
+    assert data["metrics"][0]["status"] == "unhealthy"
+
+
+def test_get_metrics_status_combined_with_service():
+    client.post("/metrics", json={"service": "web", "status": "healthy", "response_time_ms": 1})
+    client.post("/metrics", json={"service": "web", "status": "unhealthy", "response_time_ms": 2})
+    client.post("/metrics", json={"service": "db", "status": "unhealthy", "response_time_ms": 3})
+    resp = client.get("/metrics?service=web&status=unhealthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["metrics"][0]["service"] == "web"
+    assert data["metrics"][0]["status"] == "unhealthy"
+
+
+def test_get_metrics_rejects_invalid_status():
+    resp = client.get("/metrics?status=bogus")
+    assert resp.status_code == 422
+
+
+def test_metrics_store_filter_status_directly():
+    s = MetricsStore()
+    s.add(MetricRecord("svc", "healthy", 1.0, time.time()))
+    s.add(MetricRecord("svc", "degraded", 2.0, time.time()))
+    assert len(s.filter(status="degraded")) == 1
+    assert len(s.filter(status="healthy")) == 1
+    assert len(s.filter(status="unknown")) == 0

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import axios from "axios";
 import { app } from "./app";
 
 describe("API Gateway", () => {
@@ -16,6 +17,24 @@ describe("API Gateway", () => {
       const res = await request(app).get("/api/metrics");
       expect(res.status).toBe(502);
       expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("forwards status, service, since, until, limit, offset to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { metrics: [], total: 0 } } as never);
+      const res = await request(app).get(
+        "/api/metrics?service=web&status=unhealthy&since=1700000000&until=1800000000&limit=10&offset=2"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("status=unhealthy");
+      expect(calledUrl).toContain("since=1700000000");
+      expect(calledUrl).toContain("until=1800000000");
+      expect(calledUrl).toContain("limit=10");
+      expect(calledUrl).toContain("offset=2");
+      spy.mockRestore();
     });
   });
 

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -28,6 +28,7 @@ app.get("/api/metrics", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();
     if (req.query.service) params.set("service", String(req.query.service));
+    if (req.query.status) params.set("status", String(req.query.status));
     if (req.query.since !== undefined) params.set("since", String(req.query.since));
     if (req.query.until !== undefined) params.set("until", String(req.query.until));
     if (req.query.limit !== undefined) params.set("limit", String(req.query.limit));


### PR DESCRIPTION
## 概要
- `analytics-api` の `GET /metrics` に `status` クエリを追加（`MetricPayload.status` と同じ Literal を使用）
- `MetricsStore.filter` を拡張し `status` 条件で絞り込み可能に
- `api-gateway` の `/api/metrics` でも `status` を analytics に転送
- 双方にテストを追加

## 動作確認
- `cd analytics-api && flake8 --max-line-length=120 main.py && pytest -v` → 51 passed
- `cd api-gateway && npm run lint && npm test` → 8 passed

Closes #25