### PR TITLE
feat: api-gateway の POST /api/metrics エラー伝播と DELETE /api/metrics 追加

### DIFF
--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -86,6 +86,61 @@ describe("API Gateway", () => {
       expect(res.status).toBe(502);
       expect(res.body.error).toBe("Analytics service unavailable");
     });
+
+    it("propagates 4xx validation errors from analytics", async () => {
+      const err = new AxiosError("Unprocessable Entity");
+      err.response = {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: {},
+        config: {} as never,
+        data: { detail: [{ msg: "field required", loc: ["body", "status"] }] },
+      };
+      const spy = jest.spyOn(axios, "post").mockRejectedValueOnce(err);
+      const res = await request(app)
+        .post("/api/metrics")
+        .send({ service: "test", response_time_ms: 10 });
+      expect(res.status).toBe(422);
+      expect(res.body.detail).toBeDefined();
+      spy.mockRestore();
+    });
+  });
+
+  describe("DELETE /api/metrics", () => {
+    it("forwards service query parameter and result to analytics", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: { message: "Metrics deleted", service: "web", deleted_count: 3 },
+      } as never);
+      const res = await request(app).delete("/api/metrics?service=web");
+      expect(res.status).toBe(200);
+      expect(res.body.deleted_count).toBe(3);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
+      spy.mockRestore();
+    });
+
+    it("propagates 4xx errors from analytics", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: {},
+        config: {} as never,
+        data: { detail: "service is required" },
+      };
+      const spy = jest.spyOn(axios, "delete").mockRejectedValueOnce(err);
+      const res = await request(app).delete("/api/metrics");
+      expect(res.status).toBe(422);
+      expect(res.body.detail).toContain("service is required");
+      spy.mockRestore();
+    });
+
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).delete("/api/metrics?service=web");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
   });
 
   describe("GET /api/check", () => {

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -87,11 +87,41 @@ app.post("/api/metrics", async (req: Request, res: Response) => {
     const resp = await axios.post(`${ANALYTICS_URL}/metrics`, req.body, { timeout: PROXY_TIMEOUT });
     res.status(resp.status).json(resp.data);
   } catch (err) {
-    const message =
-      err instanceof AxiosError
-        ? err.message
-        : "Unknown error";
+    if (err instanceof AxiosError && err.response) {
+      logger.warn("Analytics returned error on post", {
+        status: err.response.status,
+        data: err.response.data,
+      });
+      res.status(err.response.status).json(err.response.data);
+      return;
+    }
+    const message = err instanceof AxiosError ? err.message : "Unknown error";
     logger.error("Failed to post metric", { error: message });
+    res.status(502).json({ error: "Analytics service unavailable", detail: message });
+  }
+});
+
+app.delete("/api/metrics", async (req: Request, res: Response) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.service !== undefined) params.set("service", String(req.query.service));
+    const qs = params.toString();
+    const url = qs
+      ? `${ANALYTICS_URL}/metrics?${qs}`
+      : `${ANALYTICS_URL}/metrics`;
+    const resp = await axios.delete(url, { timeout: PROXY_TIMEOUT });
+    res.status(resp.status).json(resp.data);
+  } catch (err) {
+    if (err instanceof AxiosError && err.response) {
+      logger.warn("Analytics returned error on delete", {
+        status: err.response.status,
+        data: err.response.data,
+      });
+      res.status(err.response.status).json(err.response.data);
+      return;
+    }
+    const message = err instanceof AxiosError ? err.message : "Unknown error";
+    logger.error("Failed to delete metrics", { error: message });
     res.status(502).json({ error: "Analytics service unavailable", detail: message });
   }
 });


### PR DESCRIPTION
## 変更概要

- `api-gateway/src/app.ts`:
  - `POST /api/metrics` が `AxiosError.response` を持つ場合に backend の status/body を転送するよう修正（GET 系と挙動を統一）
  - `DELETE /api/metrics` プロキシエンドポイントを追加（`service` クエリを analytics-api に転送）
- `api-gateway/src/app.test.ts`: POST の 422 伝播テスト、DELETE の forward / 4xx 伝播 / 502 テストを追加

## 対応 Issue

- Closes #29

## 動作確認手順

```bash
cd api-gateway
npm install
npm run lint   # eslint clean
npm test       # 14 tests pass
```

