### PR TITLE
feat(analytics-api): summary にパーセンタイル追加と /metrics のソート機能

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -24,6 +24,22 @@ METRICS_DEFAULT_LIMIT = max(1, int(os.getenv("METRICS_DEFAULT_LIMIT", "100")))
 METRICS_MAX_LIMIT = max(METRICS_DEFAULT_LIMIT, int(os.getenv("METRICS_MAX_LIMIT", "1000")))
 ALLOWED_STATUSES = ("healthy", "unhealthy", "degraded", "unknown")
 StatusLiteral = Literal["healthy", "unhealthy", "degraded", "unknown"]
+SortFieldLiteral = Literal["timestamp", "service", "response_time_ms", "status"]
+SortOrderLiteral = Literal["asc", "desc"]
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100.0) * (len(sorted_values) - 1)
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return sorted_values[lower]
+    weight = rank - lower
+    return sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight
 
 
 class MetricPayload(BaseModel):
@@ -140,12 +156,19 @@ class MetricsStore:
             s["times"].append(r.response_time_ms)
         result = {}
         for svc, data in services.items():
-            avg = sum(data["times"]) / len(data["times"]) if data["times"] else 0
+            times = data["times"]
+            avg = sum(times) / len(times) if times else 0
+            sorted_times = sorted(times)
             result[svc] = {
                 "total_checks": data["total"],
                 "healthy_checks": data["healthy"],
                 "uptime_pct": round(data["healthy"] / data["total"] * 100, 2) if data["total"] else 0,
                 "avg_response_ms": round(avg, 2),
+                "min_response_ms": round(sorted_times[0], 2) if sorted_times else 0.0,
+                "max_response_ms": round(sorted_times[-1], 2) if sorted_times else 0.0,
+                "p50_response_ms": round(_percentile(sorted_times, 50), 2),
+                "p95_response_ms": round(_percentile(sorted_times, 95), 2),
+                "p99_response_ms": round(_percentile(sorted_times, 99), 2),
             }
         return result
 
@@ -199,6 +222,14 @@ def get_metrics(
         ge=0,
         description="先頭から読み飛ばす件数",
     ),
+    sort: SortFieldLiteral = Query(
+        default="timestamp",
+        description="ソートフィールド（timestamp / service / response_time_ms / status）",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（asc / desc）",
+    ),
 ):
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -211,6 +242,8 @@ def get_metrics(
         raise HTTPException(status_code=400, detail="until must be a finite number")
 
     records = store.filter(service=service, status=status, since=since, until=until)
+    reverse = order == "desc"
+    records = sorted(records, key=lambda r: getattr(r, sort), reverse=reverse)
     total = len(records)
     page = records[offset:offset + limit]
     return {
@@ -218,6 +251,8 @@ def get_metrics(
         "total": total,
         "limit": limit,
         "offset": offset,
+        "sort": sort,
+        "order": order,
         "metrics": [r.__dict__ for r in page],
     }
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -508,3 +508,70 @@ def test_metrics_store_filter_status_directly():
     assert len(s.filter(status="degraded")) == 1
     assert len(s.filter(status="healthy")) == 1
     assert len(s.filter(status="unknown")) == 0
+
+
+def test_summary_includes_min_max_and_percentiles():
+    for i in range(1, 11):
+        client.post(
+            "/metrics",
+            json={"service": "svc-p", "status": "healthy", "response_time_ms": float(i * 10)},
+        )
+    resp = client.get("/metrics/summary")
+    assert resp.status_code == 200
+    data = resp.json()["svc-p"]
+    assert data["min_response_ms"] == 10.0
+    assert data["max_response_ms"] == 100.0
+    assert data["p50_response_ms"] == 55.0
+    assert data["p95_response_ms"] >= 90.0
+    assert data["p99_response_ms"] >= 95.0
+
+
+def test_summary_percentile_single_sample():
+    client.post("/metrics", json={"service": "single", "status": "healthy", "response_time_ms": 42.0})
+    resp = client.get("/metrics/summary")
+    data = resp.json()["single"]
+    assert data["min_response_ms"] == 42.0
+    assert data["max_response_ms"] == 42.0
+    assert data["p50_response_ms"] == 42.0
+    assert data["p95_response_ms"] == 42.0
+    assert data["p99_response_ms"] == 42.0
+
+
+def test_get_metrics_sort_by_response_time_asc():
+    for v in [50.0, 10.0, 30.0]:
+        client.post("/metrics", json={"service": "svc", "status": "healthy", "response_time_ms": v})
+    resp = client.get("/metrics?sort=response_time_ms&order=asc")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sort"] == "response_time_ms"
+    assert data["order"] == "asc"
+    rts = [m["response_time_ms"] for m in data["metrics"]]
+    assert rts == [10.0, 30.0, 50.0]
+
+
+def test_get_metrics_sort_by_response_time_desc():
+    for v in [50.0, 10.0, 30.0]:
+        client.post("/metrics", json={"service": "svc", "status": "healthy", "response_time_ms": v})
+    resp = client.get("/metrics?sort=response_time_ms&order=desc")
+    assert resp.status_code == 200
+    rts = [m["response_time_ms"] for m in resp.json()["metrics"]]
+    assert rts == [50.0, 30.0, 10.0]
+
+
+def test_get_metrics_sort_by_service_alpha():
+    client.post("/metrics", json={"service": "zebra", "status": "healthy", "response_time_ms": 1.0})
+    client.post("/metrics", json={"service": "apple", "status": "healthy", "response_time_ms": 2.0})
+    client.post("/metrics", json={"service": "mango", "status": "healthy", "response_time_ms": 3.0})
+    resp = client.get("/metrics?sort=service")
+    services = [m["service"] for m in resp.json()["metrics"]]
+    assert services == ["apple", "mango", "zebra"]
+
+
+def test_get_metrics_rejects_invalid_sort_field():
+    resp = client.get("/metrics?sort=bogus")
+    assert resp.status_code == 422
+
+
+def test_get_metrics_rejects_invalid_sort_order():
+    resp = client.get("/metrics?order=sideways")
+    assert resp.status_code == 422


### PR DESCRIPTION
## 変更概要

- `MetricsStore.summary` の出力に `min_response_ms` / `max_response_ms` / `p50_response_ms` / `p95_response_ms` / `p99_response_ms` を追加（線形補間方式のパーセンタイル計算ヘルパ `_percentile` を導入）
- `GET /metrics` に `sort`(`timestamp` / `service` / `response_time_ms` / `status`)と `order`(`asc` / `desc`)を追加。`Literal` 型で型バリデーション、不正値は 422 を返す
- レスポンスにも `sort` / `order` を含め、クライアントが現在のソート条件を確認可能に
- 上記をカバーする 7 件のテストを追加

Closes #31

## 動作確認

- `cd analytics-api && python -m pytest test_main.py -q` → 63 件すべてパス
- `python -m flake8 --max-line-length=120 --exclude=__pycache__ main.py` → 警告なし
- 既存の 56 テストはすべて互換性を保ったまま通過、新規 7 テストでパーセンタイル計算とソート挙動を検証
