### PR TITLE
feat: サービス発見用エンドポイント /metrics/services の追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -26,6 +26,9 @@ ALLOWED_STATUSES = ("healthy", "unhealthy", "degraded", "unknown")
 StatusLiteral = Literal["healthy", "unhealthy", "degraded", "unknown"]
 SortFieldLiteral = Literal["timestamp", "service", "response_time_ms", "status"]
 SortOrderLiteral = Literal["asc", "desc"]
+ServiceSortFieldLiteral = Literal[
+    "service", "total_checks", "last_seen", "first_seen", "latest_status"
+]
 
 
 def _percentile(sorted_values: list[float], pct: float) -> float:
@@ -303,6 +306,93 @@ def get_summary(
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
     return store.summary(service=service, status=status, since=since, until=until)
+
+
+@app.get("/metrics/services")
+def list_services(
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"最新ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+    sort: ServiceSortFieldLiteral = Query(
+        default="service",
+        description=(
+            "ソートフィールド（service / total_checks / last_seen / first_seen / latest_status）"
+        ),
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（asc / desc）",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+):
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    records = store.filter(since=since, until=until)
+    by_service: dict[str, dict] = {}
+    for r in records:
+        existing = by_service.get(r.service)
+        if existing is None:
+            by_service[r.service] = {
+                "service": r.service,
+                "total_checks": 1,
+                "first_seen": r.timestamp,
+                "last_seen": r.timestamp,
+                "latest_status": r.status,
+            }
+            continue
+        existing["total_checks"] += 1
+        if r.timestamp < existing["first_seen"]:
+            existing["first_seen"] = r.timestamp
+        if r.timestamp >= existing["last_seen"]:
+            existing["last_seen"] = r.timestamp
+            existing["latest_status"] = r.status
+
+    services = list(by_service.values())
+    if status is not None:
+        services = [s for s in services if s["latest_status"] == status]
+
+    reverse = order == "desc"
+    services.sort(key=lambda s: s[sort], reverse=reverse)
+    total = len(services)
+    page = services[offset:offset + limit]
+    return {
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "sort": sort,
+        "order": order,
+        "services": page,
+    }
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -575,3 +575,132 @@ def test_get_metrics_rejects_invalid_sort_field():
 def test_get_metrics_rejects_invalid_sort_order():
     resp = client.get("/metrics?order=sideways")
     assert resp.status_code == 422
+
+
+def test_list_services_empty():
+    resp = client.get("/metrics/services")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["services"] == []
+    assert data["sort"] == "service"
+
+
+def test_list_services_distinct_aggregation():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 2.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy", "response_time_ms": 3.0, "timestamp": 150.0,
+    })
+    resp = client.get("/metrics/services")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    by_name = {s["service"]: s for s in data["services"]}
+    assert by_name["web"]["total_checks"] == 2
+    assert by_name["web"]["first_seen"] == 100.0
+    assert by_name["web"]["last_seen"] == 200.0
+    assert by_name["web"]["latest_status"] == "unhealthy"
+    assert by_name["db"]["total_checks"] == 1
+    assert by_name["db"]["latest_status"] == "healthy"
+
+
+def test_list_services_default_sorted_by_service_asc():
+    client.post("/metrics", json={"service": "zebra", "status": "healthy", "response_time_ms": 1.0})
+    client.post("/metrics", json={"service": "apple", "status": "healthy", "response_time_ms": 1.0})
+    client.post("/metrics", json={"service": "mango", "status": "healthy", "response_time_ms": 1.0})
+    resp = client.get("/metrics/services")
+    names = [s["service"] for s in resp.json()["services"]]
+    assert names == ["apple", "mango", "zebra"]
+
+
+def test_list_services_sort_by_total_checks_desc():
+    for _ in range(3):
+        client.post("/metrics", json={
+            "service": "busy", "status": "healthy", "response_time_ms": 1.0,
+        })
+    client.post("/metrics", json={
+        "service": "quiet", "status": "healthy", "response_time_ms": 1.0,
+    })
+    resp = client.get("/metrics/services?sort=total_checks&order=desc")
+    names = [s["service"] for s in resp.json()["services"]]
+    assert names == ["busy", "quiet"]
+
+
+def test_list_services_sort_by_last_seen_desc():
+    client.post("/metrics", json={
+        "service": "old", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "new", "status": "healthy", "response_time_ms": 1.0, "timestamp": 200.0,
+    })
+    resp = client.get("/metrics/services?sort=last_seen&order=desc")
+    names = [s["service"] for s in resp.json()["services"]]
+    assert names == ["new", "old"]
+
+
+def test_list_services_filter_by_status():
+    client.post("/metrics", json={
+        "service": "down", "status": "unhealthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "ok", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?status=unhealthy")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "down"
+
+
+def test_list_services_time_range_filter():
+    client.post("/metrics", json={
+        "service": "old", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "new", "status": "healthy", "response_time_ms": 1.0, "timestamp": 500.0,
+    })
+    resp = client.get("/metrics/services?since=400")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "new"
+
+
+def test_list_services_pagination():
+    for name in ["a", "b", "c", "d", "e"]:
+        client.post("/metrics", json={
+            "service": name, "status": "healthy", "response_time_ms": 1.0,
+        })
+    resp = client.get("/metrics/services?limit=2&offset=1")
+    data = resp.json()
+    assert data["count"] == 2
+    assert data["total"] == 5
+    assert [s["service"] for s in data["services"]] == ["b", "c"]
+
+
+def test_list_services_rejects_invalid_sort():
+    resp = client.get("/metrics/services?sort=bogus")
+    assert resp.status_code == 422
+
+
+def test_list_services_rejects_until_before_since():
+    resp = client.get("/metrics/services?since=200&until=100")
+    assert resp.status_code == 400
+
+
+def test_list_services_latest_status_uses_most_recent_timestamp():
+    # Out-of-order arrival: later timestamp should win even if posted first
+    client.post("/metrics", json={
+        "service": "svc", "status": "healthy", "response_time_ms": 1.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "svc", "status": "unhealthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services")
+    data = resp.json()
+    assert data["services"][0]["latest_status"] == "healthy"
+    assert data["services"][0]["last_seen"] == 200.0
+    assert data["services"][0]["first_seen"] == 100.0

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -78,6 +78,48 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("GET /api/metrics/services", () => {
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/services");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("forwards status/since/until/sort/order/limit/offset to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { services: [], total: 0 } } as never);
+      const res = await request(app).get(
+        "/api/metrics/services?status=healthy&since=100&until=200&sort=last_seen&order=desc&limit=5&offset=1"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("status=healthy");
+      expect(calledUrl).toContain("since=100");
+      expect(calledUrl).toContain("until=200");
+      expect(calledUrl).toContain("sort=last_seen");
+      expect(calledUrl).toContain("order=desc");
+      expect(calledUrl).toContain("limit=5");
+      expect(calledUrl).toContain("offset=1");
+      spy.mockRestore();
+    });
+
+    it("propagates 4xx errors from analytics", async () => {
+      const err = new AxiosError("Unprocessable Entity");
+      err.response = {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: {},
+        config: {} as never,
+        data: { detail: "Input should be one of" },
+      };
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/services?sort=bogus");
+      expect(res.status).toBe(422);
+      spy.mockRestore();
+    });
+  });
+
   describe("POST /api/metrics", () => {
     it("returns 502 when analytics is down", async () => {
       const res = await request(app)

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -82,6 +82,37 @@ app.get("/api/metrics/summary", async (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/metrics/services", async (req: Request, res: Response) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.status) params.set("status", String(req.query.status));
+    if (req.query.since !== undefined) params.set("since", String(req.query.since));
+    if (req.query.until !== undefined) params.set("until", String(req.query.until));
+    if (req.query.sort) params.set("sort", String(req.query.sort));
+    if (req.query.order) params.set("order", String(req.query.order));
+    if (req.query.limit !== undefined) params.set("limit", String(req.query.limit));
+    if (req.query.offset !== undefined) params.set("offset", String(req.query.offset));
+    const qs = params.toString();
+    const url = qs
+      ? `${ANALYTICS_URL}/metrics/services?${qs}`
+      : `${ANALYTICS_URL}/metrics/services`;
+    const resp = await axios.get(url, { timeout: PROXY_TIMEOUT });
+    res.json(resp.data);
+  } catch (err) {
+    if (err instanceof AxiosError && err.response) {
+      logger.warn("Analytics returned error", {
+        status: err.response.status,
+        data: err.response.data,
+      });
+      res.status(err.response.status).json(err.response.data);
+      return;
+    }
+    const message = err instanceof AxiosError ? err.message : "Unknown error";
+    logger.error("Failed to fetch services", { error: message });
+    res.status(502).json({ error: "Analytics service unavailable", detail: message });
+  }
+});
+
 app.post("/api/metrics", async (req: Request, res: Response) => {
   try {
     const resp = await axios.post(`${ANALYTICS_URL}/metrics`, req.body, { timeout: PROXY_TIMEOUT });


### PR DESCRIPTION
## 変更概要

- `analytics-api/main.py` に `GET /metrics/services` を実装
  - 集約フィールド: `service`, `total_checks`, `first_seen`, `last_seen`, `latest_status`
  - クエリ: `status` / `since` / `until` / `sort` / `order` / `limit` / `offset`
  - `latest_status` は最も新しい timestamp のステータスを採用するため、順不同投稿でも結果が安定
- `analytics-api/test_main.py` に 11 件のテストを追加（集約・ソート・各種フィルタ・ページネーション・順不同検証）
- `api-gateway/src/app.ts` に `/api/metrics/services` プロキシを追加（クエリ転送・4xx 伝播）
- `api-gateway/src/app.test.ts` に 3 件のテストを追加（502・パラメータ転送・エラー伝播）

Closes #33

## 動作確認手順

```
# Python
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v   # 74 passed (新規 11 件を含む)

# TypeScript
cd api-gateway
npm ci && npm run lint && npm test   # 17 passed (新規 3 件を含む)
```