### PR TITLE
feat: analytics-api に POST /metrics/batch を追加し、api-gateway 経由でも公開する

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -6,8 +6,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Literal
 
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel, Field, field_validator
+from fastapi import FastAPI, HTTPException, Query, Request, Response
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -22,6 +22,7 @@ MAX_SERVICE_LENGTH = 100
 MAX_RESPONSE_TIME_MS = 60_000.0
 METRICS_DEFAULT_LIMIT = max(1, int(os.getenv("METRICS_DEFAULT_LIMIT", "100")))
 METRICS_MAX_LIMIT = max(METRICS_DEFAULT_LIMIT, int(os.getenv("METRICS_MAX_LIMIT", "1000")))
+BATCH_MAX_SIZE = max(1, int(os.getenv("METRICS_BATCH_MAX_SIZE", "500")))
 ALLOWED_STATUSES = ("healthy", "unhealthy", "degraded", "unknown")
 StatusLiteral = Literal["healthy", "unhealthy", "degraded", "unknown"]
 SortFieldLiteral = Literal["timestamp", "service", "response_time_ms", "status"]
@@ -195,6 +196,84 @@ def post_metric(payload: MetricPayload):
     )
     store.add(record)
     return {"recorded": True, "service": record.service, "timestamp": record.timestamp}
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    parts = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err.get("loc", ()) if p != "")
+        msg = err.get("msg", "invalid")
+        if loc:
+            parts.append(f"{loc}: {msg}")
+        else:
+            parts.append(msg)
+    return "; ".join(parts) if parts else "invalid payload"
+
+
+@app.post("/metrics/batch")
+async def post_metrics_batch(request: Request, response: Response):
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+    metrics = body.get("metrics")
+    if not isinstance(metrics, list):
+        raise HTTPException(status_code=400, detail="Field 'metrics' must be an array")
+    if len(metrics) == 0:
+        raise HTTPException(status_code=400, detail="Field 'metrics' must not be empty")
+    if len(metrics) > BATCH_MAX_SIZE:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Field 'metrics' must contain at most {BATCH_MAX_SIZE} items",
+        )
+
+    accepted: list[dict] = []
+    rejected: list[dict] = []
+    for index, item in enumerate(metrics):
+        if not isinstance(item, dict):
+            rejected.append({"index": index, "error": "item must be a JSON object"})
+            continue
+        try:
+            payload = MetricPayload.model_validate(item)
+        except ValidationError as e:
+            rejected.append({"index": index, "error": _format_validation_error(e)})
+            continue
+        record = MetricRecord(
+            service=payload.service,
+            status=payload.status,
+            response_time_ms=payload.response_time_ms,
+            timestamp=payload.timestamp or time.time(),
+        )
+        store.add(record)
+        accepted.append({
+            "index": index,
+            "service": record.service,
+            "timestamp": record.timestamp,
+        })
+
+    total = len(metrics)
+    if len(rejected) == total:
+        status_code = 400
+    elif rejected:
+        status_code = 207  # Multi-Status: partial success
+    else:
+        status_code = 201
+
+    logger.info(
+        "Batch ingest: total=%d accepted=%d rejected=%d",
+        total, len(accepted), len(rejected),
+    )
+
+    response.status_code = status_code
+    return {
+        "total": total,
+        "accepted_count": len(accepted),
+        "rejected_count": len(rejected),
+        "accepted": accepted,
+        "rejected": rejected,
+    }
 
 
 @app.get("/metrics")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -704,3 +704,105 @@ def test_list_services_latest_status_uses_most_recent_timestamp():
     assert data["services"][0]["latest_status"] == "healthy"
     assert data["services"][0]["last_seen"] == 200.0
     assert data["services"][0]["first_seen"] == 100.0
+
+
+def test_post_metrics_batch_all_valid():
+    payload = {
+        "metrics": [
+            {"service": "web", "status": "healthy", "response_time_ms": 10.0},
+            {"service": "db", "status": "unhealthy", "response_time_ms": 200.0},
+            {"service": "cache", "status": "healthy", "response_time_ms": 5.0},
+        ],
+    }
+    resp = client.post("/metrics/batch", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["accepted_count"] == 3
+    assert data["rejected_count"] == 0
+    assert len(data["accepted"]) == 3
+    assert data["rejected"] == []
+    # Records actually persisted
+    list_resp = client.get("/metrics")
+    assert list_resp.json()["total"] == 3
+
+
+def test_post_metrics_batch_partial_success_returns_207():
+    payload = {
+        "metrics": [
+            {"service": "web", "status": "healthy", "response_time_ms": 10.0},
+            {"service": "", "status": "healthy", "response_time_ms": 5.0},  # invalid
+            {"service": "db", "status": "bogus", "response_time_ms": 1.0},  # invalid
+        ],
+    }
+    resp = client.post("/metrics/batch", json=payload)
+    assert resp.status_code == 207
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["accepted_count"] == 1
+    assert data["rejected_count"] == 2
+    rejected_indexes = [r["index"] for r in data["rejected"]]
+    assert rejected_indexes == [1, 2]
+    list_resp = client.get("/metrics")
+    assert list_resp.json()["total"] == 1
+
+
+def test_post_metrics_batch_all_invalid_returns_400():
+    payload = {
+        "metrics": [
+            {"service": "", "status": "healthy", "response_time_ms": 10.0},
+            {"service": "db", "status": "wrong", "response_time_ms": 1.0},
+        ],
+    }
+    resp = client.post("/metrics/batch", json=payload)
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["total"] == 2
+    assert data["accepted_count"] == 0
+    assert data["rejected_count"] == 2
+    list_resp = client.get("/metrics")
+    assert list_resp.json()["total"] == 0
+
+
+def test_post_metrics_batch_empty_array_rejected():
+    resp = client.post("/metrics/batch", json={"metrics": []})
+    assert resp.status_code == 400
+
+
+def test_post_metrics_batch_missing_metrics_field():
+    resp = client.post("/metrics/batch", json={})
+    assert resp.status_code == 400
+
+
+def test_post_metrics_batch_non_object_body():
+    resp = client.post("/metrics/batch", json=[1, 2, 3])
+    assert resp.status_code == 400
+
+
+def test_post_metrics_batch_non_object_item():
+    resp = client.post("/metrics/batch", json={"metrics": ["not-an-object"]})
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["rejected_count"] == 1
+    assert data["rejected"][0]["index"] == 0
+
+
+def test_post_metrics_batch_exceeds_max_size():
+    metrics = [
+        {"service": f"s{i}", "status": "healthy", "response_time_ms": 1.0}
+        for i in range(501)
+    ]
+    resp = client.post("/metrics/batch", json={"metrics": metrics})
+    assert resp.status_code == 400
+    assert "at most" in resp.json()["detail"]
+
+
+def test_post_metrics_batch_respects_max_size():
+    metrics = [
+        {"service": f"s{i}", "status": "healthy", "response_time_ms": 1.0}
+        for i in range(500)
+    ]
+    resp = client.post("/metrics/batch", json={"metrics": metrics})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["accepted_count"] == 500

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -148,6 +148,73 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("POST /api/metrics/batch", () => {
+    it("forwards body to analytics and propagates 207 partial success", async () => {
+      const spy = jest.spyOn(axios, "post").mockResolvedValueOnce({
+        status: 207,
+        data: {
+          total: 2,
+          accepted_count: 1,
+          rejected_count: 1,
+          accepted: [{ index: 0, service: "web", timestamp: 1700000000 }],
+          rejected: [{ index: 1, error: "service: must not be blank" }],
+        },
+      } as never);
+      const res = await request(app)
+        .post("/api/metrics/batch")
+        .send({
+          metrics: [
+            { service: "web", status: "healthy", response_time_ms: 10 },
+            { service: "", status: "healthy", response_time_ms: 5 },
+          ],
+        });
+      expect(res.status).toBe(207);
+      expect(res.body.accepted_count).toBe(1);
+      expect(res.body.rejected_count).toBe(1);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/batch");
+      spy.mockRestore();
+    });
+
+    it("propagates 201 when all entries accepted", async () => {
+      const spy = jest.spyOn(axios, "post").mockResolvedValueOnce({
+        status: 201,
+        data: { total: 1, accepted_count: 1, rejected_count: 0, accepted: [], rejected: [] },
+      } as never);
+      const res = await request(app)
+        .post("/api/metrics/batch")
+        .send({ metrics: [{ service: "web", status: "healthy", response_time_ms: 1 }] });
+      expect(res.status).toBe(201);
+      expect(res.body.accepted_count).toBe(1);
+      spy.mockRestore();
+    });
+
+    it("propagates 400 from analytics on invalid batch", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+        data: { detail: "Field 'metrics' must not be empty" },
+      };
+      const spy = jest.spyOn(axios, "post").mockRejectedValueOnce(err);
+      const res = await request(app)
+        .post("/api/metrics/batch")
+        .send({ metrics: [] });
+      expect(res.status).toBe(400);
+      spy.mockRestore();
+    });
+
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app)
+        .post("/api/metrics/batch")
+        .send({ metrics: [{ service: "web", status: "healthy", response_time_ms: 1 }] });
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+  });
+
   describe("DELETE /api/metrics", () => {
     it("forwards service query parameter and result to analytics", async () => {
       const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -132,6 +132,32 @@ app.post("/api/metrics", async (req: Request, res: Response) => {
   }
 });
 
+app.post("/api/metrics/batch", async (req: Request, res: Response) => {
+  try {
+    const resp = await axios.post(
+      `${ANALYTICS_URL}/metrics/batch`,
+      req.body,
+      {
+        timeout: PROXY_TIMEOUT,
+        validateStatus: (status: number) => status >= 200 && status < 300,
+      }
+    );
+    res.status(resp.status).json(resp.data);
+  } catch (err) {
+    if (err instanceof AxiosError && err.response) {
+      logger.warn("Analytics returned error on batch", {
+        status: err.response.status,
+        data: err.response.data,
+      });
+      res.status(err.response.status).json(err.response.data);
+      return;
+    }
+    const message = err instanceof AxiosError ? err.message : "Unknown error";
+    logger.error("Failed to post metric batch", { error: message });
+    res.status(502).json({ error: "Analytics service unavailable", detail: message });
+  }
+});
+
 app.delete("/api/metrics", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();


### PR DESCRIPTION
## 概要

- `analytics-api` に `POST /metrics/batch` を追加（1リクエストで最大 500 件取り込み可）
  - 全件成功: 201
  - 部分成功: 207 Multi-Status（受理済み・拒否済みのインデックスとエラーを返却）
  - 全件失敗・空・JSON 不正・サイズ超過: 400
  - 上限は `METRICS_BATCH_MAX_SIZE` 環境変数で変更可能（デフォルト 500）
- `api-gateway` に `POST /api/metrics/batch` のプロキシを追加（207 を透過、4xx 伝播、5xx・ネットワーク不通は 502）
- 既存テストパターンに揃えたユニットテストを追加

## 動作確認

- `cd analytics-api && flake8 --max-line-length=120 --exclude=__pycache__ main.py`: OK
- `cd analytics-api && pytest -v`: 83 件全 pass（新規 9 件追加）
- `cd api-gateway && npm run lint`: エラーなし
- `cd api-gateway && tsc --noEmit`: エラーなし
- `cd api-gateway && npm test`: 21 件全 pass（新規 4 件追加）

Closes #35