### PR TITLE
feat(api-gateway): GET /api/metrics で sort/order を analytics-api に転送する

### DIFF
--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -36,6 +36,35 @@ describe("API Gateway", () => {
       expect(calledUrl).toContain("offset=2");
       spy.mockRestore();
     });
+
+    it("forwards sort and order to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { metrics: [], total: 0 } } as never);
+      const res = await request(app).get(
+        "/api/metrics?sort=response_time_ms&order=desc"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("sort=response_time_ms");
+      expect(calledUrl).toContain("order=desc");
+      spy.mockRestore();
+    });
+
+    it("propagates 4xx errors from analytics on invalid sort", async () => {
+      const err = new AxiosError("Unprocessable Entity");
+      err.response = {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: {},
+        config: {} as never,
+        data: { detail: "Input should be one of" },
+      };
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics?sort=bogus");
+      expect(res.status).toBe(422);
+      spy.mockRestore();
+    });
   });
 
   describe("GET /api/metrics/summary", () => {

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -33,6 +33,8 @@ app.get("/api/metrics", async (req: Request, res: Response) => {
     if (req.query.until !== undefined) params.set("until", String(req.query.until));
     if (req.query.limit !== undefined) params.set("limit", String(req.query.limit));
     if (req.query.offset !== undefined) params.set("offset", String(req.query.offset));
+    if (req.query.sort) params.set("sort", String(req.query.sort));
+    if (req.query.order) params.set("order", String(req.query.order));
     const qs = params.toString();
     const url = qs
       ? `${ANALYTICS_URL}/metrics?${qs}`


### PR DESCRIPTION
## 概要

- `api-gateway` の `GET /api/metrics` プロキシで取りこぼしていた `sort` / `order` クエリパラメータを analytics-api に転送するよう修正
- 既に `/api/metrics/services` 側では転送実装済みだったため、それと整合
- 新規テスト 2 件を追加: sort/order の転送確認 / analytics-api 由来の 4xx 伝播

## 変更ファイル

- `api-gateway/src/app.ts`
- `api-gateway/src/app.test.ts`

## 動作確認

- `npm run lint` がパス
- `npm test` で 23 件全てパス（新規 2 件含む）

Closes #37