### PR TITLE
feat: DELETE /metrics に時間ベース削除 (?before=) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,29 @@ Response:
 | GET | `/health` | Health check |
 | POST | `/metrics` | Record a health check metric |
 | GET | `/metrics` | List metrics (`?service=`, `?since=`, `?until=`, `?limit=`, `?offset=`） |
-| DELETE | `/metrics?service=` | サービス名指定で対象メトリクスを削除 |
+| DELETE | `/metrics` | サービス名 / 時刻 を組合せて対象メトリクスを削除（`?service=` / `?before=`） |
 | GET | `/metrics/summary` | Per-service summary statistics |
+
+#### Delete Metrics
+
+`?service=` と `?before=`（Unix timestamp）の一方または両方を指定する。両方とも未指定の場合は 400。
+
+```bash
+# サービス名指定（全件削除）
+curl -X DELETE "http://localhost:8001/metrics?service=web"
+
+# 時刻ベース削除（指定 timestamp より前のレコードを削除、境界は strict <）
+curl -X DELETE "http://localhost:8001/metrics?before=1700000000"
+
+# 組合せ（AND 条件：web で timestamp が 1700000000 より前のレコードのみ削除）
+curl -X DELETE "http://localhost:8001/metrics?service=web&before=1700000000"
+```
+
+レスポンス:
+
+```json
+{"message":"Metrics deleted","service":"web","before":1700000000,"deleted_count":3}
+```
 
 #### List Metrics (paginated)
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -139,6 +139,35 @@ class MetricsStore:
             logger.info("Deleted %d records for service=%s", deleted, service)
         return deleted
 
+    def delete(self, service: str | None = None, before: float | None = None) -> int:
+        """Delete records matching the given filters.
+
+        Records are removed only when they match every provided filter:
+        - service: only records whose service equals this value
+        - before:  only records whose timestamp is strictly less than this value
+        """
+        if service is None and before is None:
+            return 0
+        with self._lock:
+            initial = len(self.records)
+            kept: list[MetricRecord] = []
+            for r in self.records:
+                if service is not None and r.service != service:
+                    kept.append(r)
+                    continue
+                if before is not None and r.timestamp >= before:
+                    kept.append(r)
+                    continue
+                # falls through both filters → delete
+            self.records = kept
+            deleted = initial - len(self.records)
+        if deleted > 0:
+            logger.info(
+                "Deleted %d records (service=%s, before=%s)",
+                deleted, service, before,
+            )
+        return deleted
+
     def summary(
         self,
         service: str | None = None,
@@ -341,20 +370,46 @@ def get_metrics(
 
 @app.delete("/metrics")
 def delete_metrics(
-    service: str = Query(
-        ...,
-        description="削除対象のサービス名",
+    service: str | None = Query(
+        default=None,
+        description="削除対象のサービス名（省略時は service で絞り込まない）",
         min_length=1,
         max_length=MAX_SERVICE_LENGTH,
     ),
+    before: float | None = Query(
+        default=None,
+        gt=0,
+        description=(
+            "この Unix timestamp より前（<）のレコードを削除。"
+            "service と組み合わせると AND 条件になる"
+        ),
+    ),
 ):
-    normalized = service.strip()
-    if not normalized:
+    if before is not None and not math.isfinite(before):
+        raise HTTPException(status_code=400, detail="before must be a finite number")
+    normalized = service.strip() if service is not None else None
+    if normalized is not None and not normalized:
         return {"error": "service must not be blank", "deleted_count": 0}
-    deleted = store.delete_by_service(normalized)
+    if normalized is None and before is None:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one of 'service' or 'before' must be provided",
+        )
+    deleted = store.delete(service=normalized, before=before)
     if deleted == 0:
-        return {"error": "No metrics found for the specified service", "deleted_count": 0}
-    return {"message": "Metrics deleted", "service": normalized, "deleted_count": deleted}
+        message = "No metrics matched the given filters"
+        return {
+            "error": message,
+            "deleted_count": 0,
+            "service": normalized,
+            "before": before,
+        }
+    return {
+        "message": "Metrics deleted",
+        "service": normalized,
+        "before": before,
+        "deleted_count": deleted,
+    }
 
 
 @app.get("/metrics/summary")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -358,8 +358,94 @@ def test_delete_metrics_not_found():
 
 
 def test_delete_metrics_missing_param():
+    # service と before のどちらも未指定の場合は 400 で拒否される
     resp = client.delete("/metrics")
-    assert resp.status_code == 422
+    assert resp.status_code == 400
+    assert "service" in resp.json()["detail"]
+    assert "before" in resp.json()["detail"]
+
+
+def test_delete_metrics_by_before_only():
+    # before のみ指定で古いレコードだけ削除されることを確認
+    base = time.time()
+    client.post("/metrics", json={
+        "service": "old", "status": "healthy",
+        "response_time_ms": 10, "timestamp": base - 1000,
+    })
+    client.post("/metrics", json={
+        "service": "mid", "status": "healthy",
+        "response_time_ms": 20, "timestamp": base - 500,
+    })
+    client.post("/metrics", json={
+        "service": "new", "status": "healthy",
+        "response_time_ms": 30, "timestamp": base,
+    })
+
+    cutoff = base - 400
+    resp = client.delete(f"/metrics?before={cutoff}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_count"] == 2  # old と mid が削除される
+    assert data["service"] is None
+    assert data["before"] == cutoff
+
+    remaining = client.get("/metrics").json()
+    remaining_services = sorted(m["service"] for m in remaining["metrics"])
+    assert remaining_services == ["new"]
+
+
+def test_delete_metrics_by_service_and_before_combined():
+    # service と before の AND 条件で削除されることを確認
+    base = time.time()
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy",
+        "response_time_ms": 10, "timestamp": base - 1000,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy",
+        "response_time_ms": 20, "timestamp": base,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy",
+        "response_time_ms": 30, "timestamp": base - 1000,
+    })
+
+    cutoff = base - 500
+    resp = client.delete(f"/metrics?service=web&before={cutoff}")
+    assert resp.status_code == 200
+    data = resp.json()
+    # web で base - 1000 のレコード 1 件だけ削除される
+    assert data["deleted_count"] == 1
+    assert data["service"] == "web"
+    assert data["before"] == cutoff
+
+    remaining = client.get("/metrics").json()
+    remaining_pairs = sorted(
+        (m["service"], int(m["timestamp"])) for m in remaining["metrics"]
+    )
+    assert remaining_pairs == [
+        ("db", int(base - 1000)),
+        ("web", int(base)),
+    ]
+
+
+def test_delete_metrics_by_before_rejects_non_positive():
+    # before は gt=0 でバリデーションされ 0 以下は 422
+    for value in ("0", "-1"):
+        resp = client.delete(f"/metrics?before={value}")
+        assert resp.status_code == 422, value
+
+
+def test_delete_metrics_before_no_match_returns_zero():
+    client.post("/metrics", json={
+        "service": "svc", "status": "healthy",
+        "response_time_ms": 1, "timestamp": time.time(),
+    })
+    resp = client.delete("/metrics?before=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_count"] == 0
+    assert "error" in data
 
 
 def test_delete_metrics_updates_summary():
@@ -383,6 +469,47 @@ def test_metrics_store_delete_by_service_unit():
     assert deleted == 2
     assert len(s.get_all()) == 1
     assert s.get_all()[0].service == "b"
+
+
+def test_metrics_store_delete_unit():
+    # service のみ
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="b", status="healthy", response_time_ms=20, timestamp=100))
+    assert s.delete(service="a") == 1
+    assert [r.service for r in s.get_all()] == ["b"]
+
+    # before のみ
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=20, timestamp=200))
+    s.add(MetricRecord(service="b", status="healthy", response_time_ms=30, timestamp=50))
+    assert s.delete(before=150) == 2  # timestamp 100 と 50 が削除
+    remaining = sorted((r.service, r.timestamp) for r in s.get_all())
+    assert remaining == [("a", 200)]
+
+    # service + before の AND
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=20, timestamp=300))
+    s.add(MetricRecord(service="b", status="healthy", response_time_ms=30, timestamp=100))
+    assert s.delete(service="a", before=200) == 1  # a で timestamp 100 のみ
+    remaining = sorted((r.service, r.timestamp) for r in s.get_all())
+    assert remaining == [("a", 300), ("b", 100)]
+
+    # service=None かつ before=None は何もしない
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    assert s.delete() == 0
+    assert len(s.get_all()) == 1
+
+    # before の境界: timestamp == before のレコードは「削除しない」(strict <)
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=20, timestamp=99.999))
+    assert s.delete(before=100) == 1
+    remaining = [r.timestamp for r in s.get_all()]
+    assert remaining == [100]
 
 
 def test_metrics_store_delete_nonexistent():

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -258,6 +258,48 @@ describe("API Gateway", () => {
       spy.mockRestore();
     });
 
+    it("forwards before query parameter to analytics", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: { message: "Metrics deleted", before: 1700000000, deleted_count: 5 },
+      } as never);
+      const res = await request(app).delete("/api/metrics?before=1700000000");
+      expect(res.status).toBe(200);
+      expect(res.body.deleted_count).toBe(5);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("before=1700000000");
+      spy.mockRestore();
+    });
+
+    it("forwards both service and before to analytics", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: { message: "Metrics deleted", service: "web", before: 1700000000, deleted_count: 2 },
+      } as never);
+      const res = await request(app).delete("/api/metrics?service=web&before=1700000000");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("before=1700000000");
+      spy.mockRestore();
+    });
+
+    it("propagates 400 when neither service nor before are provided", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+        data: { detail: "At least one of 'service' or 'before' must be provided" },
+      };
+      const spy = jest.spyOn(axios, "delete").mockRejectedValueOnce(err);
+      const res = await request(app).delete("/api/metrics");
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toContain("service");
+      spy.mockRestore();
+    });
+
     it("propagates 4xx errors from analytics", async () => {
       const err = new AxiosError("Bad Request");
       err.response = {

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -164,6 +164,7 @@ app.delete("/api/metrics", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();
     if (req.query.service !== undefined) params.set("service", String(req.query.service));
+    if (req.query.before !== undefined) params.set("before", String(req.query.before));
     const qs = params.toString();
     const url = qs
       ? `${ANALYTICS_URL}/metrics?${qs}`


### PR DESCRIPTION
## 変更概要

- `MetricsStore.delete(service, before)` を追加し、`service` 単独 / `before` 単独 / 両者 AND を扱う
- `DELETE /metrics` の `service` を Optional に変更し、`?before=<unix_timestamp>` を新規サポート
  - 境界は strict `<` （`timestamp == before` は残す）
  - `before` は `gt=0` でバリデーション、両方未指定は 400
- `api-gateway` の `DELETE /api/metrics` に `before` パススルーを追加
- 既存 `delete_by_service` と既存テストは温存（後方互換）
- README に DELETE エンドポイントの説明とサンプルを追加

## 動作確認手順

```bash
# analytics-api 単体
cd analytics-api && pip install -r requirements.txt
pytest -v  # 88 件すべて pass

# api-gateway 単体
cd api-gateway && npm install
npm run lint && npm test  # 26 件すべて pass

# health-checker（変更なし、確認のみ）
cd health-checker && go vet ./... && go test -v ./...

# 手動 e2e
make up
curl -X POST localhost:8000/api/metrics -H 'Content-Type: application/json' \
  -d '{"service":"web","status":"healthy","response_time_ms":10,"timestamp":1}'
curl -X DELETE 'localhost:8000/api/metrics?before=2'
# → {"deleted_count":1,"service":null,"before":2,...}
```

Closes #41