### PR TITLE
feat(health-checker): ReportMetric にリトライ＋指数バックオフを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ curl "http://localhost:8001/metrics?service=web&since=1700000000"
 | GET | `/health` | Health check |
 | GET | `/check` | Run health checks on all configured targets |
 
+**メトリクス報告の再送 (Metric reporting retries):**
+
+各ターゲットのチェック結果は analytics-api の `POST /metrics` に送信される。
+analytics-api の一時的な障害（接続エラー、5xx、429 Too Many Requests）に対しては
+指数バックオフで自動リトライする。
+
+- 試行回数は `METRIC_REPORT_MAX_ATTEMPTS`（既定 `3`、`1` でリトライ無効）
+- 初期バックオフは `METRIC_REPORT_BACKOFF_MS`（既定 `100`）。`backoff × 2^(n-1)` で増加
+- 4xx（429 を除く）はリクエスト不備なので即時失敗とする
+
 ## Configuration
 
 All services are configured via environment variables. See [`.env.example`](.env.example) for the full list.
@@ -219,6 +229,8 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `CHECKER_READ_TIMEOUT` | `15` | Health Checker: HTTP リクエスト全体の読み取りタイムアウト（秒） |
 | `CHECKER_WRITE_TIMEOUT` | `15` | Health Checker: HTTP レスポンス書き込みタイムアウト（秒） |
 | `CHECKER_IDLE_TIMEOUT` | `60` | Health Checker: keep-alive アイドルタイムアウト（秒） |
+| `METRIC_REPORT_MAX_ATTEMPTS` | `3` | Health Checker: analytics-api への POST `/metrics` 最大試行回数（`1` でリトライ無効） |
+| `METRIC_REPORT_BACKOFF_MS` | `100` | Health Checker: メトリクス報告の指数バックオフ初期値（ミリ秒） |
 
 ## Testing
 

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -97,7 +97,64 @@ func CheckService(client *http.Client, target ServiceTarget) CheckResult {
 	return result
 }
 
+// reportMetricRetryPolicy は ReportMetric の試行回数とバックオフ初期値をまとめた値。
+// 環境変数で上書きされる。
+type reportMetricRetryPolicy struct {
+	maxAttempts int
+	backoff     time.Duration
+}
+
+func loadRetryPolicy() reportMetricRetryPolicy {
+	return reportMetricRetryPolicy{
+		maxAttempts: envIntAtLeastOne("METRIC_REPORT_MAX_ATTEMPTS", 3),
+		backoff:     envMillis("METRIC_REPORT_BACKOFF_MS", 100*time.Millisecond),
+	}
+}
+
+func envIntAtLeastOne(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return fallback
+}
+
+func envMillis(key string, fallback time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return time.Duration(n) * time.Millisecond
+		}
+	}
+	return fallback
+}
+
+// shouldRetryStatus は HTTP ステータスコードがリトライに値するかを返す。
+// 5xx は一時的障害として再試行し、429 (Too Many Requests) も対象。
+// それ以外の 4xx はクライアント不備なので即時失敗とする。
+func shouldRetryStatus(code int) bool {
+	if code >= 500 && code < 600 {
+		return true
+	}
+	if code == http.StatusTooManyRequests {
+		return true
+	}
+	return false
+}
+
+// ReportMetric は analytics-api に 1 件のメトリクスを POST する。
+// 一時的失敗（接続エラー / 5xx / 429）に対しては指数バックオフで自動リトライする。
+// 試行回数・バックオフ初期値は METRIC_REPORT_MAX_ATTEMPTS / METRIC_REPORT_BACKOFF_MS で上書き可。
 func ReportMetric(client *http.Client, analyticsURL string, result CheckResult) error {
+	return reportMetricWithPolicy(client, analyticsURL, result, loadRetryPolicy())
+}
+
+func reportMetricWithPolicy(
+	client *http.Client,
+	analyticsURL string,
+	result CheckResult,
+	policy reportMetricRetryPolicy,
+) error {
 	payload := map[string]interface{}{
 		"service":          result.Service,
 		"status":           result.Status,
@@ -109,18 +166,52 @@ func ReportMetric(client *http.Client, analyticsURL string, result CheckResult) 
 		return fmt.Errorf("marshal payload: %w", err)
 	}
 
-	resp, err := client.Post(analyticsURL+"/metrics", "application/json", bytes.NewReader(body))
-	if err != nil {
-		log.Printf("[WARN] Failed to report metric for %s: %v", result.Service, err)
-		return err
-	}
-	defer resp.Body.Close()
+	var lastErr error
+	for attempt := 1; attempt <= policy.maxAttempts; attempt++ {
+		resp, err := client.Post(analyticsURL+"/metrics", "application/json", bytes.NewReader(body))
+		if err != nil {
+			lastErr = err
+			log.Printf(
+				"[WARN] Report attempt %d/%d failed for %s: %v",
+				attempt, policy.maxAttempts, result.Service, err,
+			)
+		} else {
+			statusCode := resp.StatusCode
+			resp.Body.Close()
+			if statusCode == http.StatusCreated {
+				log.Printf(
+					"[INFO] Reported metric for %s to analytics (attempt %d)",
+					result.Service, attempt,
+				)
+				return nil
+			}
+			lastErr = fmt.Errorf("analytics API returned %d", statusCode)
+			if !shouldRetryStatus(statusCode) {
+				// 4xx (429 除く) は即時失敗。リトライしない。
+				log.Printf(
+					"[WARN] Report for %s aborted (non-retryable %d)",
+					result.Service, statusCode,
+				)
+				return lastErr
+			}
+			log.Printf(
+				"[WARN] Report attempt %d/%d for %s returned %d",
+				attempt, policy.maxAttempts, result.Service, statusCode,
+			)
+		}
 
-	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("analytics API returned %d", resp.StatusCode)
+		if attempt >= policy.maxAttempts {
+			break
+		}
+		// 指数バックオフ: backoff * 2^(attempt-1)
+		sleep := policy.backoff * (1 << (attempt - 1))
+		time.Sleep(sleep)
 	}
-	log.Printf("[INFO] Reported metric for %s to analytics", result.Service)
-	return nil
+	log.Printf(
+		"[WARN] Failed to report metric for %s after %d attempt(s): %v",
+		result.Service, policy.maxAttempts, lastErr,
+	)
+	return lastErr
 }
 
 func NewTargets() []ServiceTarget {

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -408,3 +409,200 @@ func TestCheckHandler_MultipleTargets(t *testing.T) {
 	}
 }
 
+
+// テスト用の高速リトライポリシー。指数バックオフは活かしつつ実時間は最小化する。
+var testRetryPolicy = reportMetricRetryPolicy{maxAttempts: 3, backoff: 1 * time.Millisecond}
+
+// TestReportMetric_RetriesOn5xxThenSucceeds は最初の試行で 500 を返し、
+// 2 回目で 201 を返すサーバに対し、リトライにより最終的に成功することを確認する。
+func TestReportMetric_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	result := CheckResult{Service: "flaky", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+	if err := reportMetricWithPolicy(server.Client(), server.URL, result, testRetryPolicy); err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 calls, got %d", got)
+	}
+}
+
+// TestReportMetric_RetriesOn429 は 429 Too Many Requests もリトライ対象であることを確認する。
+func TestReportMetric_RetriesOn429(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	result := CheckResult{Service: "ratelimited", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+	if err := reportMetricWithPolicy(server.Client(), server.URL, result, testRetryPolicy); err != nil {
+		t.Fatalf("expected success after retry on 429, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("expected 3 calls, got %d", got)
+	}
+}
+
+// TestReportMetric_DoesNotRetryOn4xx は 400 番台（429 除く）が即時失敗となり、
+// 不要なリトライをしないことを確認する。
+func TestReportMetric_DoesNotRetryOn4xx(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	result := CheckResult{Service: "bad", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+	err := reportMetricWithPolicy(server.Client(), server.URL, result, testRetryPolicy)
+	if err == nil {
+		t.Fatal("expected error for 400, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected exactly 1 call (no retry on 4xx), got %d", got)
+	}
+}
+
+// TestReportMetric_GivesUpAfterMaxAttempts は持続的に 503 を返すサーバに対し、
+// 試行回数を使い切って失敗することを確認する。
+func TestReportMetric_GivesUpAfterMaxAttempts(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	policy := reportMetricRetryPolicy{maxAttempts: 4, backoff: 1 * time.Millisecond}
+	result := CheckResult{Service: "down", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+	err := reportMetricWithPolicy(server.Client(), server.URL, result, policy)
+	if err == nil {
+		t.Fatal("expected failure after exhausting retries, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 4 {
+		t.Errorf("expected 4 attempts, got %d", got)
+	}
+}
+
+// TestReportMetric_SingleAttemptDisablesRetry は maxAttempts=1 にすると
+// リトライが無効になることを確認する。
+func TestReportMetric_SingleAttemptDisablesRetry(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	policy := reportMetricRetryPolicy{maxAttempts: 1, backoff: 1 * time.Millisecond}
+	result := CheckResult{Service: "once", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+	err := reportMetricWithPolicy(server.Client(), server.URL, result, policy)
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected 1 attempt when maxAttempts=1, got %d", got)
+	}
+}
+
+// TestReportMetric_UsesExponentialBackoff は試行間の sleep が指数的に伸びることを
+// 経過時間で間接的に検証する。
+func TestReportMetric_UsesExponentialBackoff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	// 3 試行 → 試行間に 2 回 sleep → 50ms + 100ms = 150ms 程度かかる想定。
+	policy := reportMetricRetryPolicy{maxAttempts: 3, backoff: 50 * time.Millisecond}
+	result := CheckResult{Service: "slow", Status: "healthy", ResponseTimeMs: 10, Timestamp: 1}
+
+	start := time.Now()
+	_ = reportMetricWithPolicy(server.Client(), server.URL, result, policy)
+	elapsed := time.Since(start)
+
+	if elapsed < 140*time.Millisecond {
+		t.Errorf("expected at least 140ms (50+100), got %v — backoff not exponential?", elapsed)
+	}
+	// 余裕を持って上限 1s 以内
+	if elapsed > 1*time.Second {
+		t.Errorf("expected under 1s, got %v", elapsed)
+	}
+}
+
+// TestShouldRetryStatus は分類関数の境界条件を確認する。
+func TestShouldRetryStatus(t *testing.T) {
+	cases := []struct {
+		code int
+		want bool
+	}{
+		{500, true},
+		{502, true},
+		{503, true},
+		{599, true},
+		{429, true},
+		{400, false},
+		{401, false},
+		{404, false},
+		{409, false},
+		{201, false},
+		{200, false},
+		{301, false},
+	}
+	for _, c := range cases {
+		if got := shouldRetryStatus(c.code); got != c.want {
+			t.Errorf("shouldRetryStatus(%d): got %v, want %v", c.code, got, c.want)
+		}
+	}
+}
+
+// TestEnvIntAtLeastOne は env パーサが 0 や負数を fallback に戻すことを確認する。
+func TestEnvIntAtLeastOne(t *testing.T) {
+	t.Setenv("RETRY_OK", "5")
+	if got := envIntAtLeastOne("RETRY_OK", 1); got != 5 {
+		t.Errorf("got %d, want 5", got)
+	}
+	t.Setenv("RETRY_ZERO", "0")
+	if got := envIntAtLeastOne("RETRY_ZERO", 7); got != 7 {
+		t.Errorf("0 should fall back: got %d, want 7", got)
+	}
+	t.Setenv("RETRY_NEG", "-3")
+	if got := envIntAtLeastOne("RETRY_NEG", 7); got != 7 {
+		t.Errorf("negative should fall back: got %d, want 7", got)
+	}
+	t.Setenv("RETRY_BAD", "xyz")
+	if got := envIntAtLeastOne("RETRY_BAD", 9); got != 9 {
+		t.Errorf("non-numeric should fall back: got %d, want 9", got)
+	}
+}
+
+// TestEnvMillis は ミリ秒 env パーサの挙動を確認する。
+func TestEnvMillis(t *testing.T) {
+	t.Setenv("BACKOFF_OK", "250")
+	if got := envMillis("BACKOFF_OK", 100*time.Millisecond); got != 250*time.Millisecond {
+		t.Errorf("got %v, want 250ms", got)
+	}
+	t.Setenv("BACKOFF_ZERO", "0")
+	if got := envMillis("BACKOFF_ZERO", 100*time.Millisecond); got != 0 {
+		t.Errorf("zero allowed: got %v", got)
+	}
+	t.Setenv("BACKOFF_BAD", "abc")
+	if got := envMillis("BACKOFF_BAD", 100*time.Millisecond); got != 100*time.Millisecond {
+		t.Errorf("non-numeric fallback: got %v", got)
+	}
+}


### PR DESCRIPTION
## 概要

`health-checker` のメトリクス報告は単発の POST しか行わず、analytics-api の一時的な再起動・5xx・429 でメトリクスを失っていた。本 PR で bounded retry + 指数バックオフを追加して取りこぼしを防ぐ。

## 変更点

- `health-checker/main.go`:
  - `reportMetricRetryPolicy` を導入し、試行回数と初期バックオフを構造体化
  - 接続エラー / 5xx / 429 をリトライ対象に、4xx (429除く) は即時失敗
  - 指数バックオフ: `backoff × 2^(attempt-1)`
  - 環境変数 `METRIC_REPORT_MAX_ATTEMPTS`（既定 `3`）と `METRIC_REPORT_BACKOFF_MS`（既定 `100`）で挙動を制御可能
- `health-checker/main_test.go`: 新規テスト 8 件追加
  - `TestReportMetric_RetriesOn5xxThenSucceeds`: 一時的 500 後に成功
  - `TestReportMetric_RetriesOn429`: 429 もリトライ対象
  - `TestReportMetric_DoesNotRetryOn4xx`: 400 は即時失敗（1 回のみ呼ばれる）
  - `TestReportMetric_GivesUpAfterMaxAttempts`: 持続的 503 で試行回数を使い切る
  - `TestReportMetric_SingleAttemptDisablesRetry`: `maxAttempts=1` でリトライ無効
  - `TestReportMetric_UsesExponentialBackoff`: 経過時間で指数バックオフを検証
  - `TestShouldRetryStatus`: ステータス分類の境界条件
  - `TestEnvIntAtLeastOne` / `TestEnvMillis`: env パーサ
- `README.md`: リトライポリシーと新規環境変数の説明

Closes #43

## 動作確認

```
$ cd health-checker && go vet ./... && go test -v ./...
...
PASS
ok  	github.com/mohadayo/pulseboard/health-checker	1.198s
```

既存 17 件 + 新規 8 件、合計 25 件が pass。
