### PR TITLE
feat(analytics-api): /metrics/services にサービスごとの uptime/healthy 統計を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Response:
 | GET | `/metrics` | List metrics (`?service=`, `?since=`, `?until=`, `?limit=`, `?offset=`） |
 | DELETE | `/metrics` | サービス名 / 時刻 を組合せて対象メトリクスを削除（`?service=` / `?before=`） |
 | GET | `/metrics/summary` | Per-service summary statistics |
+| GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
 
 #### Delete Metrics
 
@@ -191,6 +192,58 @@ curl "http://localhost:8001/metrics?service=web&since=1700000000"
   "metrics": [{"service":"web","status":"healthy","response_time_ms":42.5,"timestamp":1700000000.0}]
 }
 ```
+
+#### List Services with Uptime
+
+`/metrics/services` はサービスごとに集約済みの観測情報を返す。レスポンスに `total_checks` / `healthy_checks` / `uptime_pct` が含まれるため、サービス一覧と稼働率を 1 リクエストで取得できる。
+
+```bash
+# デフォルト（service 名昇順）
+curl http://localhost:8001/metrics/services
+
+# 稼働率の低い順（運用上の発見クエリ）
+curl "http://localhost:8001/metrics/services?sort=uptime_pct&order=asc"
+
+# healthy 件数の多い順
+curl "http://localhost:8001/metrics/services?sort=healthy_checks&order=desc"
+```
+
+`sort` の候補は `service` / `total_checks` / `healthy_checks` / `uptime_pct` / `last_seen` / `first_seen` / `latest_status`。
+
+レスポンス例:
+
+```json
+{
+  "count": 2,
+  "total": 2,
+  "limit": 100,
+  "offset": 0,
+  "sort": "service",
+  "order": "asc",
+  "services": [
+    {
+      "service": "api",
+      "total_checks": 4,
+      "healthy_checks": 3,
+      "uptime_pct": 75.0,
+      "first_seen": 1.0,
+      "last_seen": 4.0,
+      "latest_status": "healthy"
+    },
+    {
+      "service": "db",
+      "total_checks": 2,
+      "healthy_checks": 1,
+      "uptime_pct": 50.0,
+      "first_seen": 1.0,
+      "last_seen": 2.0,
+      "latest_status": "unhealthy"
+    }
+  ]
+}
+```
+
+`uptime_pct` は `healthy_checks / total_checks * 100`（小数点 2 桁丸め、`total_checks == 0` の場合 `0`）。
 
 ### Health Checker (port 8002)
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -28,7 +28,13 @@ StatusLiteral = Literal["healthy", "unhealthy", "degraded", "unknown"]
 SortFieldLiteral = Literal["timestamp", "service", "response_time_ms", "status"]
 SortOrderLiteral = Literal["asc", "desc"]
 ServiceSortFieldLiteral = Literal[
-    "service", "total_checks", "last_seen", "first_seen", "latest_status"
+    "service",
+    "total_checks",
+    "healthy_checks",
+    "uptime_pct",
+    "last_seen",
+    "first_seen",
+    "latest_status",
 ]
 
 
@@ -461,7 +467,8 @@ def list_services(
     sort: ServiceSortFieldLiteral = Query(
         default="service",
         description=(
-            "ソートフィールド（service / total_checks / last_seen / first_seen / latest_status）"
+            "ソートフィールド（service / total_checks / healthy_checks / uptime_pct / "
+            "last_seen / first_seen / latest_status）"
         ),
     ),
     order: SortOrderLiteral = Query(
@@ -494,21 +501,31 @@ def list_services(
     by_service: dict[str, dict] = {}
     for r in records:
         existing = by_service.get(r.service)
+        is_healthy = 1 if r.status == "healthy" else 0
         if existing is None:
             by_service[r.service] = {
                 "service": r.service,
                 "total_checks": 1,
+                "healthy_checks": is_healthy,
                 "first_seen": r.timestamp,
                 "last_seen": r.timestamp,
                 "latest_status": r.status,
             }
             continue
         existing["total_checks"] += 1
+        existing["healthy_checks"] += is_healthy
         if r.timestamp < existing["first_seen"]:
             existing["first_seen"] = r.timestamp
         if r.timestamp >= existing["last_seen"]:
             existing["last_seen"] = r.timestamp
             existing["latest_status"] = r.status
+
+    # uptime_pct は集計確定後に一度だけ計算する（小数点 2 桁丸め）
+    for s in by_service.values():
+        total = s["total_checks"]
+        s["uptime_pct"] = (
+            round(s["healthy_checks"] / total * 100, 2) if total else 0.0
+        )
 
     services = list(by_service.values())
     if status is not None:

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -833,6 +833,78 @@ def test_list_services_latest_status_uses_most_recent_timestamp():
     assert data["services"][0]["first_seen"] == 100.0
 
 
+def test_list_services_includes_uptime_stats():
+    # api: healthy=3 / total=4 → uptime 75.0
+    # db : healthy=1 / total=2 → uptime 50.0
+    for ts, status in [(1.0, "healthy"), (2.0, "healthy"), (3.0, "unhealthy"), (4.0, "healthy")]:
+        client.post("/metrics", json={
+            "service": "api", "status": status,
+            "response_time_ms": 10.0, "timestamp": ts,
+        })
+    for ts, status in [(1.0, "healthy"), (2.0, "unhealthy")]:
+        client.post("/metrics", json={
+            "service": "db", "status": status,
+            "response_time_ms": 10.0, "timestamp": ts,
+        })
+
+    resp = client.get("/metrics/services")
+    assert resp.status_code == 200
+    services = {s["service"]: s for s in resp.json()["services"]}
+
+    assert services["api"]["total_checks"] == 4
+    assert services["api"]["healthy_checks"] == 3
+    assert services["api"]["uptime_pct"] == 75.0
+
+    assert services["db"]["total_checks"] == 2
+    assert services["db"]["healthy_checks"] == 1
+    assert services["db"]["uptime_pct"] == 50.0
+
+
+def test_list_services_uptime_pct_zero_when_no_healthy():
+    client.post("/metrics", json={
+        "service": "broken", "status": "unhealthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services")
+    svc = resp.json()["services"][0]
+    assert svc["healthy_checks"] == 0
+    assert svc["uptime_pct"] == 0
+
+
+def test_list_services_sort_by_uptime_pct_asc():
+    # low (25%), mid (50%), high (100%)
+    for ts, status in [(1.0, "healthy"), (2.0, "unhealthy"), (3.0, "unhealthy"), (4.0, "unhealthy")]:
+        client.post("/metrics", json={
+            "service": "low", "status": status, "response_time_ms": 1.0, "timestamp": ts,
+        })
+    for ts, status in [(1.0, "healthy"), (2.0, "unhealthy")]:
+        client.post("/metrics", json={
+            "service": "mid", "status": status, "response_time_ms": 1.0, "timestamp": ts,
+        })
+    for ts in [1.0, 2.0]:
+        client.post("/metrics", json={
+            "service": "high", "status": "healthy", "response_time_ms": 1.0, "timestamp": ts,
+        })
+
+    resp = client.get("/metrics/services?sort=uptime_pct&order=asc")
+    assert resp.status_code == 200
+    names = [s["service"] for s in resp.json()["services"]]
+    assert names == ["low", "mid", "high"]
+
+
+def test_list_services_sort_by_healthy_checks_desc():
+    for ts in [1.0, 2.0, 3.0]:
+        client.post("/metrics", json={
+            "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": ts,
+        })
+    client.post("/metrics", json={
+        "service": "b", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+
+    resp = client.get("/metrics/services?sort=healthy_checks&order=desc")
+    names = [s["service"] for s in resp.json()["services"]]
+    assert names == ["a", "b"]
+
+
 def test_post_metrics_batch_all_valid():
     payload = {
         "metrics": [


### PR DESCRIPTION
## 変更概要

- `GET /metrics/services` のレスポンス各サービスに以下のフィールドを追加
  - `healthy_checks`: 集計範囲内の healthy 観測数
  - `uptime_pct`: `healthy_checks / total_checks * 100`（小数点 2 桁、`total_checks == 0` の場合 `0`）
- `ServiceSortFieldLiteral` に `healthy_checks` / `uptime_pct` を追加し、稼働率順ソートに対応
- 既存フィールド（`service` / `total_checks` / `first_seen` / `last_seen` / `latest_status`）は不変（後方互換）
- 回帰テスト 4 本追加
  - `test_list_services_includes_uptime_stats`
  - `test_list_services_uptime_pct_zero_when_no_healthy`
  - `test_list_services_sort_by_uptime_pct_asc`
  - `test_list_services_sort_by_healthy_checks_desc`
- README に `/metrics/services` 仕様を追記

ダッシュボードが稼働率と一覧を 1 リクエストで取れるようになり、`/metrics/summary` との突き合わせが不要になる。

## 動作確認

- [x] `flake8 --max-line-length=120 main.py` パス
- [x] `pytest -v`: 88 → 92 件すべて成功
- [x] `go vet ./... && go test ./...`: health-checker 既存テスト不変
- [x] `npm run lint && npm test`: api-gateway 既存 26 件不変
- [x] 既存フィールドのみ要求するクエリは旧仕様と同じ JSON 形状を返す

Closes #45