### PR TITLE
fix(health-checker): timestamp をサブ秒精度に修正

### DIFF
--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -67,10 +67,14 @@ func methodAllowed(w http.ResponseWriter, r *http.Request, allowed ...string) bo
 
 func CheckService(client *http.Client, target ServiceTarget) CheckResult {
 	start := time.Now()
+	// analytics-api 側は Python の time.time() が返す float（マイクロ秒粒度）を
+	// 前提に時間絞り込み・ソートを行うため、こちらも秒未満の精度を維持する。
+	// time.Now().Unix() だと整数秒に丸められ、1 秒以内の並列チェックで
+	// 全レコードの timestamp が同値になってしまう。
 	result := CheckResult{
 		Service:   target.Name,
 		URL:       target.URL,
-		Timestamp: float64(time.Now().Unix()),
+		Timestamp: float64(time.Now().UnixNano()) / 1e9,
 	}
 
 	resp, err := client.Get(target.URL)

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -51,6 +52,46 @@ func TestCheckServiceHealthy(t *testing.T) {
 	}
 	if result.ResponseTimeMs < 0 {
 		t.Errorf("response time should be >= 0, got %f", result.ResponseTimeMs)
+	}
+}
+
+func TestCheckServiceTimestampSubSecondPrecision(t *testing.T) {
+	// CheckResult.Timestamp は秒未満の精度を持つこと（analytics-api 側の
+	// time.time() と粒度を合わせ、1 秒以内の連続チェックで衝突しないため）
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := server.Client()
+	target := ServiceTarget{Name: "ts-svc", URL: server.URL + "/health"}
+
+	results := make([]CheckResult, 5)
+	for i := 0; i < 5; i++ {
+		results[i] = CheckService(client, target)
+	}
+
+	// 少なくとも 1 件は秒未満の小数部分を持つはず。整数秒に丸められていると常に 0 になる。
+	hasFractional := false
+	for _, r := range results {
+		_, frac := math.Modf(r.Timestamp)
+		if frac != 0 {
+			hasFractional = true
+			break
+		}
+	}
+	if !hasFractional {
+		t.Errorf("expected at least one timestamp to have a sub-second component, got: %+v", results)
+	}
+
+	// 単調非減少（時刻が逆行しないこと）も確認しておく
+	for i := 1; i < len(results); i++ {
+		if results[i].Timestamp < results[i-1].Timestamp {
+			t.Errorf(
+				"timestamps must be monotonic non-decreasing: results[%d]=%f < results[%d]=%f",
+				i, results[i].Timestamp, i-1, results[i-1].Timestamp,
+			)
+		}
 	}
 }
 


### PR DESCRIPTION
## 概要

- `health-checker/main.go` の `CheckService` 内で生成する `CheckResult.Timestamp` を `float64(time.Now().Unix())`（整数秒）から `float64(time.Now().UnixNano()) / 1e9`（サブ秒精度）に変更
- analytics-api 側は Python の `time.time()` が返す float（マイクロ秒粒度）を前提に時間絞り込み・ソートを行うため、こちらも精度を揃える
- 1 秒以内に複数サービスを並列チェックした際、報告されるレコードの `timestamp` がすべて同値になり、`?sort=timestamp` や `?since/until` の精度が落ちる問題を解消
- 回帰テスト `TestCheckServiceTimestampSubSecondPrecision` を追加（連続呼び出しで小数部分を持ち、単調非減少であることを検証）

Closes #47

## 動作確認

- [x] `cd health-checker && go vet ./...` 通過
- [x] `cd health-checker && go test -v ./...` 全テスト pass（既存 + 新規 1 件）