### PR TITLE
feat(analytics-api): 全サービス横断の稼働サマリ /metrics/overview を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ npm start
 | GET | `/health` | Health check |
 | GET | `/api/metrics` | List all metrics (proxy to Analytics API) |
 | GET | `/api/metrics/summary` | Per-service uptime and response time summary |
+| GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API） |
 | POST | `/api/metrics` | Record a metric (proxy to Analytics API) |
 | GET | `/api/check` | Run health checks on all targets (proxy to Checker) |
 | GET | `/api/status` | Aggregated health status of all internal services |
@@ -128,6 +129,33 @@ Response:
 }
 ```
 
+#### Get Overview
+
+サービスごとではなく、フィルタ後の全レコードを 1 つに集約した全体像を返す。
+ダッシュボードのヘッダで「いま全体でどうなっているか」を 1 リクエストで把握する用途。
+`?service=` / `?status=` / `?since=` / `?until=` で絞り込める。
+
+```bash
+curl http://localhost:8000/api/metrics/overview
+```
+
+Response:
+
+```json
+{
+  "total_records": 30,
+  "services_count": 3,
+  "status_counts": {"healthy": 27, "unhealthy": 2, "degraded": 1, "unknown": 0},
+  "overall_uptime_pct": 90.0,
+  "response_time_ms": {
+    "avg": 45.2, "min": 10.0, "max": 320.0,
+    "p50": 40.0, "p95": 180.0, "p99": 300.0
+  },
+  "earliest_timestamp": 1700000000.0,
+  "latest_timestamp": 1700003600.0
+}
+```
+
 ### Analytics API (port 8001)
 
 | Method | Endpoint | Description |
@@ -137,6 +165,7 @@ Response:
 | GET | `/metrics` | List metrics (`?service=`, `?since=`, `?until=`, `?limit=`, `?offset=`） |
 | DELETE | `/metrics` | サービス名 / 時刻 を組合せて対象メトリクスを削除（`?service=` / `?before=`） |
 | GET | `/metrics/summary` | Per-service summary statistics |
+| GET | `/metrics/overview` | 全レコードを 1 つに集約したトップレベル稼働サマリ（`?service=` / `?status=` / `?since=` / `?until=`） |
 | GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
 
 #### Delete Metrics

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -211,6 +211,57 @@ class MetricsStore:
             }
         return result
 
+    def overview(
+        self,
+        service: str | None = None,
+        status: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> dict:
+        """Return a single global aggregate across all (filtered) records.
+
+        個別サービス単位ではなく、フィルタ後の全レコードを 1 つに集約した
+        トップレベルの稼働サマリを返す。ダッシュボードのヘッダ表示など、
+        「全体で今どうなっているか」を 1 リクエストで把握する用途を想定。
+        """
+        records_snapshot = self.filter(
+            service=service, status=status, since=since, until=until,
+        )
+        status_counts: dict[str, int] = {s: 0 for s in ALLOWED_STATUSES}
+        services: set[str] = set()
+        times: list[float] = []
+        earliest: float | None = None
+        latest: float | None = None
+        for r in records_snapshot:
+            services.add(r.service)
+            status_counts[r.status] = status_counts.get(r.status, 0) + 1
+            times.append(r.response_time_ms)
+            if earliest is None or r.timestamp < earliest:
+                earliest = r.timestamp
+            if latest is None or r.timestamp > latest:
+                latest = r.timestamp
+
+        total = len(records_snapshot)
+        healthy = status_counts.get("healthy", 0)
+        sorted_times = sorted(times)
+        avg = sum(times) / len(times) if times else 0.0
+        return {
+            "total_records": total,
+            "services_count": len(services),
+            "status_counts": status_counts,
+            "overall_uptime_pct": round(healthy / total * 100, 2) if total else 0.0,
+            "response_time_ms": {
+                "avg": round(avg, 2),
+                "min": round(sorted_times[0], 2) if sorted_times else 0.0,
+                "max": round(sorted_times[-1], 2) if sorted_times else 0.0,
+                "p50": round(_percentile(sorted_times, 50), 2),
+                "p95": round(_percentile(sorted_times, 95), 2),
+                "p99": round(_percentile(sorted_times, 99), 2),
+            },
+            "earliest_timestamp": earliest,
+            "latest_timestamp": latest,
+        }
+
 
 store = MetricsStore()
 
@@ -446,6 +497,36 @@ def get_summary(
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
     return store.summary(service=service, status=status, since=since, until=until)
+
+
+@app.get("/metrics/overview")
+def get_overview(
+    service: str | None = None,
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）のレコードに絞り込む",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）のレコードに絞り込む",
+    ),
+):
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+    return store.overview(service=service, status=status, since=since, until=until)
 
 
 @app.get("/metrics/services")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1005,3 +1005,104 @@ def test_post_metrics_batch_respects_max_size():
     assert resp.status_code == 201
     data = resp.json()
     assert data["accepted_count"] == 500
+
+
+# --- /metrics/overview -------------------------------------------------------
+
+def test_overview_empty_store():
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_records"] == 0
+    assert data["services_count"] == 0
+    assert data["overall_uptime_pct"] == 0.0
+    assert data["status_counts"] == {
+        "healthy": 0,
+        "unhealthy": 0,
+        "degraded": 0,
+        "unknown": 0,
+    }
+    assert data["earliest_timestamp"] is None
+    assert data["latest_timestamp"] is None
+    assert data["response_time_ms"]["avg"] == 0.0
+
+
+def test_overview_aggregates_across_services():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 10, "timestamp": 100.0})
+    client.post("/metrics", json={"service": "a", "status": "unhealthy", "response_time_ms": 30, "timestamp": 200.0})
+    client.post("/metrics", json={"service": "b", "status": "healthy", "response_time_ms": 20, "timestamp": 300.0})
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_records"] == 3
+    assert data["services_count"] == 2
+    assert data["status_counts"]["healthy"] == 2
+    assert data["status_counts"]["unhealthy"] == 1
+    # 2 of 3 healthy
+    assert data["overall_uptime_pct"] == 66.67
+    assert data["earliest_timestamp"] == 100.0
+    assert data["latest_timestamp"] == 300.0
+    rt = data["response_time_ms"]
+    assert rt["min"] == 10.0
+    assert rt["max"] == 30.0
+    assert rt["avg"] == 20.0
+
+
+def test_overview_filter_by_service():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "b", "status": "unhealthy", "response_time_ms": 50})
+    resp = client.get("/metrics/overview?service=a")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_records"] == 1
+    assert data["services_count"] == 1
+    assert data["overall_uptime_pct"] == 100.0
+
+
+def test_overview_filter_by_status():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "a", "status": "degraded", "response_time_ms": 40})
+    resp = client.get("/metrics/overview?status=degraded")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_records"] == 1
+    assert data["status_counts"]["degraded"] == 1
+    assert data["status_counts"]["healthy"] == 0
+
+
+def test_overview_filter_by_time_range():
+    for ts in (100.0, 200.0, 300.0):
+        client.post(
+            "/metrics",
+            json={"service": "a", "status": "healthy", "response_time_ms": ts / 10, "timestamp": ts},
+        )
+    resp = client.get("/metrics/overview?since=150&until=250")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_records"] == 1
+    assert data["earliest_timestamp"] == 200.0
+    assert data["latest_timestamp"] == 200.0
+
+
+def test_overview_invalid_range():
+    resp = client.get("/metrics/overview?since=200&until=100")
+    assert resp.status_code == 400
+
+
+def test_overview_invalid_status():
+    resp = client.get("/metrics/overview?status=bogus")
+    assert resp.status_code == 422
+
+
+def test_overview_store_unit_percentiles():
+    s = MetricsStore()
+    for i in range(1, 101):
+        s.add(MetricRecord(
+            service="svc", status="healthy", response_time_ms=float(i), timestamp=float(i)
+        ))
+    result = s.overview()
+    assert result["total_records"] == 100
+    assert result["services_count"] == 1
+    assert result["response_time_ms"]["p50"] == 50.5
+    assert result["response_time_ms"]["p95"] == 95.05
+    assert result["overall_uptime_pct"] == 100.0

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -107,6 +107,50 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("GET /api/metrics/overview", () => {
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/overview");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("forwards service/status/since/until to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { total_records: 0, services_count: 0 },
+        } as never);
+      const res = await request(app).get(
+        "/api/metrics/overview?service=web&status=healthy&since=100&until=200"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/overview");
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("status=healthy");
+      expect(calledUrl).toContain("since=100");
+      expect(calledUrl).toContain("until=200");
+      spy.mockRestore();
+    });
+
+    it("propagates 4xx errors from analytics", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+        data: { detail: "since must be less than or equal to until" },
+      };
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/overview?since=200&until=100");
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toContain("since must be less than or equal to until");
+      spy.mockRestore();
+    });
+  });
+
   describe("GET /api/metrics/services", () => {
     it("returns 502 when analytics is down", async () => {
       const res = await request(app).get("/api/metrics/services");

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -84,6 +84,34 @@ app.get("/api/metrics/summary", async (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/metrics/overview", async (req: Request, res: Response) => {
+  try {
+    const params = new URLSearchParams();
+    if (req.query.service) params.set("service", String(req.query.service));
+    if (req.query.status) params.set("status", String(req.query.status));
+    if (req.query.since !== undefined) params.set("since", String(req.query.since));
+    if (req.query.until !== undefined) params.set("until", String(req.query.until));
+    const qs = params.toString();
+    const url = qs
+      ? `${ANALYTICS_URL}/metrics/overview?${qs}`
+      : `${ANALYTICS_URL}/metrics/overview`;
+    const resp = await axios.get(url, { timeout: PROXY_TIMEOUT });
+    res.json(resp.data);
+  } catch (err) {
+    if (err instanceof AxiosError && err.response) {
+      logger.warn("Analytics returned error", {
+        status: err.response.status,
+        data: err.response.data,
+      });
+      res.status(err.response.status).json(err.response.data);
+      return;
+    }
+    const message = err instanceof AxiosError ? err.message : "Unknown error";
+    logger.error("Failed to fetch overview", { error: message });
+    res.status(502).json({ error: "Analytics service unavailable", detail: message });
+  }
+});
+
 app.get("/api/metrics/services", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();


### PR DESCRIPTION
## 変更概要

- `analytics-api` に `GET /metrics/overview` を追加。フィルタ後の全レコードを 1 つに集約し、総レコード数・監視サービス数・ステータス内訳（healthy/unhealthy/degraded/unknown）・全体稼働率・応答時間統計（avg/min/max/p50/p95/p99）・観測期間（earliest/latest）を返す。
- `?service=` / `?status=` / `?since=` / `?until=` の絞り込みに対応（既存エンドポイントと同一バリデーション。`since > until` は 400、不正 status は 422）。
- `MetricsStore.overview()` として集計ロジックを切り出し、既存の `_percentile` を再利用。
- `api-gateway` に `GET /api/metrics/overview` プロキシを追加し外部公開。
- 両サービスにテストを追加（analytics-api: pytest +8 / api-gateway: jest +3）。
- README にエンドポイント表とレスポンス例を追記。

## 対応 Issue

Closes #53

## 動作確認手順

```bash
# analytics-api
cd analytics-api && pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v

# api-gateway
cd api-gateway && npm ci
npm run lint
npm test
```

ローカルで flake8 / pytest(100 passed) / eslint / jest(29 passed) がすべてグリーンであることを確認済み。