### PR TITLE
feat(analytics-api): /metrics/services に service フィルタを追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -531,6 +531,12 @@ def get_overview(
 
 @app.get("/metrics/services")
 def list_services(
+    service: str | None = Query(
+        default=None,
+        description="サービス名で絞り込み（指定時は該当サービスのみ集計）",
+        min_length=1,
+        max_length=MAX_SERVICE_LENGTH,
+    ),
     status: StatusLiteral | None = Query(
         default=None,
         description=f"最新ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
@@ -578,7 +584,13 @@ def list_services(
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
 
-    records = store.filter(since=since, until=until)
+    # service は POST 時に strip 保存されるため、ここでも strip して照合する。
+    # 空白のみの場合はフィルタなし扱い（None）とする。
+    normalized_service = service.strip() if service is not None else None
+    if not normalized_service:
+        normalized_service = None
+
+    records = store.filter(service=normalized_service, since=since, until=until)
     by_service: dict[str, dict] = {}
     for r in records:
         existing = by_service.get(r.service)

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -808,6 +808,88 @@ def test_list_services_pagination():
     assert [s["service"] for s in data["services"]] == ["b", "c"]
 
 
+def test_list_services_filter_by_service():
+    # service 指定時は該当サービスのみ集計される
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 2.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy", "response_time_ms": 3.0, "timestamp": 150.0,
+    })
+    resp = client.get("/metrics/services?service=web")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "web"
+    assert data["services"][0]["total_checks"] == 2
+
+
+def test_list_services_filter_by_service_combined_with_status():
+    # service と status の両方を指定（AND 条件）
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "unhealthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?service=web&status=unhealthy")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "web"
+
+    # status が一致しなければ空になる
+    resp = client.get("/metrics/services?service=web&status=healthy")
+    assert resp.json()["total"] == 0
+
+
+def test_list_services_filter_by_service_strips_whitespace():
+    # service は POST 時に strip 保存されるためクエリ側も strip して照合する
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?service=%20web%20")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "web"
+
+
+def test_list_services_filter_by_service_unknown_returns_empty():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?service=nonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["services"] == []
+
+
+def test_list_services_blank_service_ignored_as_no_filter():
+    # 空白のみの service はフィルタなし扱いとなり全サービスを集計する
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?service=%20%20%20")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 2
+
+
+def test_list_services_rejects_empty_service():
+    resp = client.get("/metrics/services?service=")
+    assert resp.status_code == 422
+
+
+def test_list_services_rejects_overlong_service():
+    resp = client.get("/metrics/services?service=" + "x" * 101)
+    assert resp.status_code == 422
+
+
 def test_list_services_rejects_invalid_sort():
     resp = client.get("/metrics/services?sort=bogus")
     assert resp.status_code == 422

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -158,15 +158,16 @@ describe("API Gateway", () => {
       expect(res.body.error).toBe("Analytics service unavailable");
     });
 
-    it("forwards status/since/until/sort/order/limit/offset to analytics", async () => {
+    it("forwards service/status/since/until/sort/order/limit/offset to analytics", async () => {
       const spy = jest
         .spyOn(axios, "get")
         .mockResolvedValueOnce({ status: 200, data: { services: [], total: 0 } } as never);
       const res = await request(app).get(
-        "/api/metrics/services?status=healthy&since=100&until=200&sort=last_seen&order=desc&limit=5&offset=1"
+        "/api/metrics/services?service=web&status=healthy&since=100&until=200&sort=last_seen&order=desc&limit=5&offset=1"
       );
       expect(res.status).toBe(200);
       const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
       expect(calledUrl).toContain("status=healthy");
       expect(calledUrl).toContain("since=100");
       expect(calledUrl).toContain("until=200");

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -115,6 +115,7 @@ app.get("/api/metrics/overview", async (req: Request, res: Response) => {
 app.get("/api/metrics/services", async (req: Request, res: Response) => {
   try {
     const params = new URLSearchParams();
+    if (req.query.service) params.set("service", String(req.query.service));
     if (req.query.status) params.set("status", String(req.query.status));
     if (req.query.since !== undefined) params.set("since", String(req.query.since));
     if (req.query.until !== undefined) params.set("until", String(req.query.until));


### PR DESCRIPTION
## 変更概要
- analytics-api `/metrics/services` に `service` クエリパラメータを追加（最大 100 文字）
  - 指定時はそのサービスの観測のみを集計対象にする（既存の status / since / until と AND 条件）
  - 前後空白は strip し、空白のみ / 未指定はフィルタなし扱い
  - `service=`（空文字）や 101 文字以上は `min_length`/`max_length` により 422
- api-gateway `GET /api/metrics/services` で `service` を analytics-api へ転送
- analytics-api / api-gateway 双方にテストを追加

これで `/metrics`・`/metrics/summary`・`/metrics/overview` と同様に、単一サービスの集計を 1 リクエストで取得できるようになり、エンドポイント間の一貫性が取れる。

Closes #55

## 動作確認手順
- analytics-api: `cd analytics-api && pip install -r requirements-dev.txt && flake8 --max-line-length=120 --exclude=__pycache__ main.py && pytest -v`（107 passed）
- api-gateway: `cd api-gateway && npm ci && npm run lint && npm test`（29 passed）
- 手動例: `GET /metrics/services?service=web` → web のみの集計が返る。`GET /api/metrics/services?service=web` 経由でも同様に転送される。