### PR TITLE
feat(analytics-api): GET /metrics と /metrics/services に部分一致検索 (q) を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -123,6 +123,7 @@ class MetricsStore:
         status: str | None = None,
         since: float | None = None,
         until: float | None = None,
+        q: str | None = None,
     ) -> list[MetricRecord]:
         with self._lock:
             results = list(self.records)
@@ -134,6 +135,11 @@ class MetricsStore:
             results = [r for r in results if r.timestamp >= since]
         if until is not None:
             results = [r for r in results if r.timestamp <= until]
+        if q is not None:
+            # `q` は呼び出し側で trim 済みの想定。
+            # 大文字小文字を無視するため lower() 比較。
+            needle = q.lower()
+            results = [r for r in results if needle in r.service.lower()]
         return results
 
     def delete_by_service(self, service: str) -> int:
@@ -284,6 +290,25 @@ def post_metric(payload: MetricPayload):
     return {"recorded": True, "service": record.service, "timestamp": record.timestamp}
 
 
+def _normalize_q_param(raw: str | None) -> tuple[str | None, str | None]:
+    """`q` クエリパラメータを正規化する。
+
+    戻り値は (正規化後の値, エラーメッセージ)。
+    - None → (None, None) : 未指定（フィルタしない）
+    - trim 後が空 → (None, "q must not be blank") : 400 を返す対象
+    - 上限超過 → (None, "q is too long ...") : 400 を返す対象
+    - 正常 → (trimmed, None)
+    """
+    if raw is None:
+        return None, None
+    stripped = raw.strip()
+    if not stripped:
+        return None, "q must not be blank"
+    if len(stripped) > MAX_SERVICE_LENGTH:
+        return None, f"q must be at most {MAX_SERVICE_LENGTH} characters"
+    return stripped, None
+
+
 def _format_validation_error(exc: ValidationError) -> str:
     parts = []
     for err in exc.errors():
@@ -398,6 +423,10 @@ def get_metrics(
         default="asc",
         description="ソート順（asc / desc）",
     ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
 ):
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -408,8 +437,11 @@ def get_metrics(
         raise HTTPException(status_code=400, detail="since must be a finite number")
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
 
-    records = store.filter(service=service, status=status, since=since, until=until)
+    records = store.filter(service=service, status=status, since=since, until=until, q=q_value)
     reverse = order == "desc"
     records = sorted(records, key=lambda r: getattr(r, sort), reverse=reverse)
     total = len(records)
@@ -573,6 +605,10 @@ def list_services(
         ge=0,
         description="先頭から読み飛ばす件数",
     ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
 ):
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -583,6 +619,9 @@ def list_services(
         raise HTTPException(status_code=400, detail="since must be a finite number")
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
 
     # service は POST 時に strip 保存されるため、ここでも strip して照合する。
     # 空白のみの場合はフィルタなし扱い（None）とする。
@@ -590,7 +629,7 @@ def list_services(
     if not normalized_service:
         normalized_service = None
 
-    records = store.filter(service=normalized_service, since=since, until=until)
+    records = store.filter(service=normalized_service, since=since, until=until, q=q_value)
     by_service: dict[str, dict] = {}
     for r in records:
         existing = by_service.get(r.service)

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1188,3 +1188,79 @@ def test_overview_store_unit_percentiles():
     assert result["response_time_ms"]["p50"] == 50.5
     assert result["response_time_ms"]["p95"] == 95.05
     assert result["overall_uptime_pct"] == 100.0
+
+
+
+def _seed_for_q(services: list[str]) -> None:
+    for svc in services:
+        client.post(
+            "/metrics",
+            json={"service": svc, "status": "healthy", "response_time_ms": 10.0},
+        )
+
+
+def test_list_metrics_q_substring_case_insensitive():
+    _seed_for_q(["payments-api", "payments-worker", "auth-api", "scheduler"])
+    resp = client.get("/metrics?q=PAYMENTS")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert {m["service"] for m in data["metrics"]} == {"payments-api", "payments-worker"}
+
+
+def test_list_metrics_q_no_match():
+    _seed_for_q(["auth-api", "scheduler"])
+    resp = client.get("/metrics?q=payments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["count"] == 0
+    assert data["metrics"] == []
+
+
+def test_list_metrics_q_combined_with_service_filter_is_and():
+    _seed_for_q(["payments-api", "payments-worker", "auth-api"])
+    # service=payments-api（完全一致）かつ q=worker（部分一致） → 0 件
+    resp = client.get("/metrics?service=payments-api&q=worker")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+    # service=payments-api かつ q=payments → 1 件（payments-api のみ）
+    resp = client.get("/metrics?service=payments-api&q=payments")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+def test_list_metrics_q_blank_returns_400():
+    resp = client.get("/metrics?q=%20%20")
+    assert resp.status_code == 400
+    assert "blank" in resp.json()["detail"]
+
+
+def test_list_metrics_q_too_long_returns_400():
+    long_q = "x" * 101  # MAX_SERVICE_LENGTH = 100
+    resp = client.get(f"/metrics?q={long_q}")
+    assert resp.status_code == 400
+    assert "100" in resp.json()["detail"]
+
+
+def test_list_services_q_substring_case_insensitive():
+    _seed_for_q(["payments-api", "payments-worker", "auth-api", "scheduler"])
+    resp = client.get("/metrics/services?q=Payments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert {s["service"] for s in data["services"]} == {"payments-api", "payments-worker"}
+
+
+def test_list_services_q_combined_with_service_filter():
+    _seed_for_q(["payments-api", "payments-worker", "auth-api"])
+    resp = client.get("/metrics/services?service=payments-api&q=payments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "payments-api"
+
+
+def test_list_services_q_blank_returns_400():
+    resp = client.get("/metrics/services?q=%20%20")
+    assert resp.status_code == 400


### PR DESCRIPTION
## 概要

- `GET /metrics` と `GET /metrics/services` に `q` クエリパラメータを追加
- service 名に対する大文字小文字無視の部分一致検索
- 既存の `service` 完全一致との同時指定は AND 条件
- trim 後の空文字、`MAX_SERVICE_LENGTH` (=100) 超過は 400 を返す
- `MetricsStore.filter()` に `q` 引数を追加（store ロック内では行わず、ロック後の results に対して適用）
- 新規テスト 8 件追加（合計 115 件すべてパス、flake8 もクリア）

Closes #59

## 動作確認手順

```bash
cd analytics-api
pip install -r requirements-dev.txt
python -m pytest -v
flake8 --max-line-length=120 --exclude=__pycache__ main.py
```

手動確認例：

```bash
curl 'http://localhost:8001/metrics?q=payments'
curl 'http://localhost:8001/metrics/services?q=PAYMENTS'
curl -i 'http://localhost:8001/metrics?q=%20%20'   # → 400
```
