### PR TITLE
fix(api-gateway): JSON ボディサイズ上限を明示し 413 ハンドラを追加

### DIFF
--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -407,4 +407,29 @@ describe("API Gateway", () => {
       expect(res.body.error).toBe("Not found");
     });
   });
+
+  describe("JSON body size limit", () => {
+    it("returns 413 when POST body exceeds the configured limit", async () => {
+      // 既定 256kb を確実に超える 512KB の payload を組み立てる。
+      const huge = "a".repeat(512 * 1024);
+      const res = await request(app)
+        .post("/api/metrics")
+        .set("Content-Type", "application/json")
+        .send({ service: "web", value: huge });
+      expect(res.status).toBe(413);
+      expect(res.body.error).toBe("request body too large");
+    });
+
+    it("accepts a small JSON POST (proxies to analytics)", async () => {
+      const spy = jest
+        .spyOn(axios, "post")
+        .mockResolvedValueOnce({ status: 201, data: { recorded: true } } as never);
+      const res = await request(app)
+        .post("/api/metrics")
+        .send({ service: "web", status: "healthy", response_time_ms: 1 });
+      expect(res.status).toBe(201);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
 });

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -12,8 +12,13 @@ const ANALYTICS_URL = process.env.ANALYTICS_URL || "http://localhost:8001";
 const CHECKER_URL = process.env.CHECKER_URL || "http://localhost:8002";
 const PROXY_TIMEOUT = parseInt(process.env.PROXY_TIMEOUT || "5000", 10);
 
+// JSON ペイロードの最大サイズ。明示しないと express.json の既定 100kb で動くため、
+// 環境変数で上書きできる形で明示する。analytics-api の /metrics/batch
+// （最大 500 件）の実用サイズも収まる 256kb を既定値に置く。
+const MAX_REQUEST_BODY = process.env.MAX_REQUEST_BODY || "256kb";
+
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: MAX_REQUEST_BODY }));
 
 app.use((req: Request, _res: Response, next: NextFunction) => {
   logger.info(`${req.method} ${req.path}`, { ip: req.ip });
@@ -214,9 +219,29 @@ app.use((_req: Request, res: Response) => {
   res.status(404).json({ error: "Not found" });
 });
 
+// express.json の limit 超過は SyntaxError ではなく entity.too.large になる。
+// 既定の Express エラーハンドラに任せると HTML を返してしまうため、
+// JSON で 413 を返す専用ハンドラを 500 ハンドラの前段に置く。
+app.use(
+  (
+    err: Error & { type?: string; status?: number; statusCode?: number },
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const status = err.status ?? err.statusCode;
+    if (err && (err.type === "entity.too.large" || status === 413)) {
+      logger.warn("Request body too large", { limit: MAX_REQUEST_BODY });
+      res.status(413).json({ error: "request body too large" });
+      return;
+    }
+    next(err);
+  },
+);
+
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   logger.error("Unhandled error", { error: err.message });
   res.status(500).json({ error: "Internal server error" });
 });
 
-export { app, ANALYTICS_URL, CHECKER_URL };
+export { app, ANALYTICS_URL, CHECKER_URL, MAX_REQUEST_BODY };


### PR DESCRIPTION
## 変更概要

- `app.use(express.json({ limit: MAX_REQUEST_BODY }))` で JSON ボディ上限を明示
- 既定 `256kb`、`MAX_REQUEST_BODY` 環境変数で上書き可能
- `entity.too.large` を捕捉して 413 + `{"error":"request body too large"}` を返す（dashboard-bff と整合）
- テスト追加: 512KB の POST が 413 を返すこと / 通常サイズの POST が引き続き通ること

## 対応 Issue

Closes #61

## 動作確認手順

```
cd api-gateway
npm ci
npm run lint
npm test
```

全 32 テスト緑（既存 30 件 + 新規 2 件）を確認済み。
