### PR TITLE
feat(analytics-api): /metrics/summary と /metrics/overview に q 部分一致検索を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -186,9 +186,10 @@ class MetricsStore:
         status: str | None = None,
         since: float | None = None,
         until: float | None = None,
+        q: str | None = None,
     ) -> dict:
         records_snapshot = self.filter(
-            service=service, status=status, since=since, until=until,
+            service=service, status=status, since=since, until=until, q=q,
         )
         services: dict[str, dict] = {}
         for r in records_snapshot:
@@ -223,6 +224,7 @@ class MetricsStore:
         status: str | None = None,
         since: float | None = None,
         until: float | None = None,
+        q: str | None = None,
     ) -> dict:
         """Return a single global aggregate across all (filtered) records.
 
@@ -231,7 +233,7 @@ class MetricsStore:
         「全体で今どうなっているか」を 1 リクエストで把握する用途を想定。
         """
         records_snapshot = self.filter(
-            service=service, status=status, since=since, until=until,
+            service=service, status=status, since=since, until=until, q=q,
         )
         status_counts: dict[str, int] = {s: 0 for s in ALLOWED_STATUSES}
         services: set[str] = set()
@@ -518,6 +520,10 @@ def get_summary(
         ge=0,
         description="この Unix timestamp 以前（<=）のレコードに絞り込む",
     ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
 ):
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -528,7 +534,12 @@ def get_summary(
         raise HTTPException(status_code=400, detail="since must be a finite number")
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
-    return store.summary(service=service, status=status, since=since, until=until)
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
+    return store.summary(
+        service=service, status=status, since=since, until=until, q=q_value,
+    )
 
 
 @app.get("/metrics/overview")
@@ -548,6 +559,10 @@ def get_overview(
         ge=0,
         description="この Unix timestamp 以前（<=）のレコードに絞り込む",
     ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
 ):
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -558,7 +573,12 @@ def get_overview(
         raise HTTPException(status_code=400, detail="since must be a finite number")
     if until is not None and not math.isfinite(until):
         raise HTTPException(status_code=400, detail="until must be a finite number")
-    return store.overview(service=service, status=status, since=since, until=until)
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
+    return store.overview(
+        service=service, status=status, since=since, until=until, q=q_value,
+    )
 
 
 @app.get("/metrics/services")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -325,6 +325,35 @@ def test_summary_invalid_status():
     assert resp.status_code == 422
 
 
+def test_summary_filter_by_q_partial_match():
+    client.post("/metrics", json={"service": "payments-api", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "payments-worker", "status": "healthy", "response_time_ms": 20})
+    client.post("/metrics", json={"service": "orders-api", "status": "unhealthy", "response_time_ms": 30})
+    resp = client.get("/metrics/summary?q=payments")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"payments-api", "payments-worker"}
+
+
+def test_summary_q_case_insensitive():
+    client.post("/metrics", json={"service": "Payments-API", "status": "healthy", "response_time_ms": 10})
+    resp = client.get("/metrics/summary?q=PAYMENTS")
+    assert resp.status_code == 200
+    assert "Payments-API" in resp.json()
+
+
+def test_summary_q_blank_rejected():
+    # 既存 /metrics と挙動を揃え、trim 後が空の q は 400 を返す。
+    resp = client.get("/metrics/summary?q=%20%20")
+    assert resp.status_code == 400
+    assert "blank" in resp.json()["detail"]
+
+
+def test_summary_q_too_long_rejected():
+    resp = client.get("/metrics/summary?q=" + "x" * 9999)
+    assert resp.status_code == 400
+
+
 def test_get_metrics_unknown_service():
     resp = client.get("/metrics?service=nonexistent")
     assert resp.status_code == 200
@@ -1174,6 +1203,37 @@ def test_overview_invalid_range():
 def test_overview_invalid_status():
     resp = client.get("/metrics/overview?status=bogus")
     assert resp.status_code == 422
+
+
+def test_overview_filter_by_q_partial_match():
+    client.post("/metrics", json={"service": "payments-api", "status": "healthy", "response_time_ms": 10})
+    client.post("/metrics", json={"service": "payments-worker", "status": "healthy", "response_time_ms": 20})
+    client.post("/metrics", json={"service": "orders-api", "status": "unhealthy", "response_time_ms": 30})
+    resp = client.get("/metrics/overview?q=payments")
+    assert resp.status_code == 200
+    data = resp.json()
+    # payments-api と payments-worker のみカウント
+    assert data["total_records"] == 2
+    assert data["services_count"] == 2
+
+
+def test_overview_q_case_insensitive():
+    client.post("/metrics", json={"service": "Payments-API", "status": "healthy", "response_time_ms": 10})
+    resp = client.get("/metrics/overview?q=PAYMENTS")
+    assert resp.status_code == 200
+    assert resp.json()["total_records"] == 1
+
+
+def test_overview_q_blank_rejected():
+    # 既存 /metrics と挙動を揃え、trim 後が空の q は 400 を返す。
+    resp = client.get("/metrics/overview?q=%20%20")
+    assert resp.status_code == 400
+    assert "blank" in resp.json()["detail"]
+
+
+def test_overview_q_too_long_rejected():
+    resp = client.get("/metrics/overview?q=" + "x" * 9999)
+    assert resp.status_code == 400
 
 
 def test_overview_store_unit_percentiles():


### PR DESCRIPTION
## 概要

- `/metrics/summary` と `/metrics/overview` に `q`（service 名への大文字小文字無視・部分一致検索）クエリパラメータを追加
- 既存 `_normalize_q_param` を再利用するため、空白のみは 400 / 上限超過は 400 と `/metrics` 既存挙動と統一
- `MetricsStore.summary` / `MetricsStore.overview` の引数にも `q` を追加し、内部の `filter(...)` 呼び出しに引き渡し

これで 4 つのメトリクスエンドポイント（`/metrics` / `/metrics/services` / `/metrics/summary` / `/metrics/overview`）すべてで同じフィルタ語彙 (`service` / `status` / `since` / `until` / `q`) が使えるようになる。

## 動作確認

- `flake8 --max-line-length=120 --exclude=__pycache__ main.py` クリーン
- `pytest -q` で 123 件パス（既存 + summary 用 3 件 + overview 用 3 件の追加）

Closes #63
