### PR TITLE
fix(api-gateway): GET /api/metrics 系の 4 エンドポイントで q 検索クエリを上流へ転送

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ npm start
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/health` | Health check |
-| GET | `/api/metrics` | List all metrics (proxy to Analytics API) |
-| GET | `/api/metrics/summary` | Per-service uptime and response time summary |
-| GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API） |
+| GET | `/api/metrics` | List all metrics (proxy to Analytics API、`?q=` で service 名部分一致検索) |
+| GET | `/api/metrics/summary` | Per-service uptime and response time summary（`?q=` で service 名部分一致検索） |
+| GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API、`?q=` で部分一致検索） |
+| GET | `/api/metrics/services` | サービス一覧（`?q=` で部分一致検索、`?sort=` / `?order=` / `?limit=` / `?offset=`） |
 | POST | `/api/metrics` | Record a metric (proxy to Analytics API) |
 | GET | `/api/check` | Run health checks on all targets (proxy to Checker) |
 | GET | `/api/status` | Aggregated health status of all internal services |
@@ -133,7 +134,7 @@ Response:
 
 サービスごとではなく、フィルタ後の全レコードを 1 つに集約した全体像を返す。
 ダッシュボードのヘッダで「いま全体でどうなっているか」を 1 リクエストで把握する用途。
-`?service=` / `?status=` / `?since=` / `?until=` で絞り込める。
+`?service=` / `?status=` / `?since=` / `?until=` で絞り込める。`?q=` で service 名の大文字小文字無視の部分一致検索も可能。
 
 ```bash
 curl http://localhost:8000/api/metrics/overview

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -51,6 +51,17 @@ describe("API Gateway", () => {
       spy.mockRestore();
     });
 
+    it("forwards q (partial-match search) to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { metrics: [], total: 0 } } as never);
+      const res = await request(app).get("/api/metrics?q=web");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("q=web");
+      spy.mockRestore();
+    });
+
     it("does not forward empty query params to analytics", async () => {
       const spy = jest
         .spyOn(axios, "get")
@@ -102,6 +113,18 @@ describe("API Gateway", () => {
       spy.mockRestore();
     });
 
+    it("forwards q (partial-match search) to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { web: { total_checks: 1 } } } as never);
+      const res = await request(app).get("/api/metrics/summary?q=web");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/summary");
+      expect(calledUrl).toContain("q=web");
+      spy.mockRestore();
+    });
+
     it("propagates 4xx errors from analytics", async () => {
       const err = new AxiosError("Bad Request");
       err.response = {
@@ -146,6 +169,21 @@ describe("API Gateway", () => {
       spy.mockRestore();
     });
 
+    it("forwards q (partial-match search) to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { total_records: 0, services_count: 0 },
+        } as never);
+      const res = await request(app).get("/api/metrics/overview?q=web");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/overview");
+      expect(calledUrl).toContain("q=web");
+      spy.mockRestore();
+    });
+
     it("propagates 4xx errors from analytics", async () => {
       const err = new AxiosError("Bad Request");
       err.response = {
@@ -187,6 +225,18 @@ describe("API Gateway", () => {
       expect(calledUrl).toContain("order=desc");
       expect(calledUrl).toContain("limit=5");
       expect(calledUrl).toContain("offset=1");
+      spy.mockRestore();
+    });
+
+    it("forwards q (partial-match search) to analytics", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { services: [], total: 0 } } as never);
+      const res = await request(app).get("/api/metrics/services?q=web");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/services");
+      expect(calledUrl).toContain("q=web");
       spy.mockRestore();
     });
 

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -74,7 +74,7 @@ app.get("/api/metrics", (req: Request, res: Response) =>
     req,
     res,
     "/metrics",
-    ["service", "status", "since", "until", "limit", "offset", "sort", "order"],
+    ["service", "status", "since", "until", "limit", "offset", "sort", "order", "q"],
     "metrics",
   ),
 );
@@ -84,7 +84,7 @@ app.get("/api/metrics/summary", (req: Request, res: Response) =>
     req,
     res,
     "/metrics/summary",
-    ["service", "status", "since", "until"],
+    ["service", "status", "since", "until", "q"],
     "summary",
   ),
 );
@@ -94,7 +94,7 @@ app.get("/api/metrics/overview", (req: Request, res: Response) =>
     req,
     res,
     "/metrics/overview",
-    ["service", "status", "since", "until"],
+    ["service", "status", "since", "until", "q"],
     "overview",
   ),
 );
@@ -104,7 +104,7 @@ app.get("/api/metrics/services", (req: Request, res: Response) =>
     req,
     res,
     "/metrics/services",
-    ["service", "status", "since", "until", "sort", "order", "limit", "offset"],
+    ["service", "status", "since", "until", "sort", "order", "limit", "offset", "q"],
     "services",
   ),
 );


### PR DESCRIPTION
## 概要

`analytics-api` が #60 / #64 で `GET /metrics`, `/metrics/summary`, `/metrics/overview`, `/metrics/services` の 4 エンドポイントに `q` 部分一致検索を実装したが、`api-gateway` 側の `proxyAnalyticsGet` の `allowedParams` に `q` が含まれておらず、ゲートウェイ経由ではこの機能が使えない状態だった。これを修正する。

## 変更点

- `api-gateway/src/app.ts`
  - `/api/metrics`, `/api/metrics/summary`, `/api/metrics/overview`, `/api/metrics/services` の `allowedParams` に `"q"` を追加
- `api-gateway/src/app.test.ts`
  - 上記 4 エンドポイントそれぞれで `?q=web` が上流 URL に正しく転送されることを確認するテストを 1 件ずつ追加（合計 4 件、計 32 → 36 ケース）
- `README.md`
  - API Gateway のエンドポイント表に `?q=` の説明を追記
  - `/api/metrics/services` のエントリを追加（README から漏れていた）
  - `Get Overview` の説明に `?q=` を補足

## 動作確認

- [x] `npm run lint`（pulseboard-api-gateway）pass
- [x] `npm test` 36 件全て pass（追加 4 件含む）
- [x] `pytest -q`（analytics-api）123 件 pass（既存ロジックは未変更）
- [x] `go test ./...`（health-checker）pass
- [x] `flake8 --max-line-length=120` clean

Closes #65