### PR TITLE
feat(analytics-api): フィルタ条件付きの軽量カウントエンドポイント /metrics/count を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -581,6 +581,57 @@ def get_overview(
     )
 
 
+@app.get("/metrics/count")
+def get_metrics_count(
+    service: str | None = None,
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）のレコードに絞り込む",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）のレコードに絞り込む",
+    ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
+):
+    """フィルタ条件に合致するレコードの件数のみを返す軽量エンドポイント。
+
+    `/metrics?limit=1` 相当のメタデータだけが必要な UI（バッジ表示・ページャ初期化等）
+    向け。レコード本体を返さないため、転送量と JSON 直列化コストを抑えられる。
+    `by_status` は `ALLOWED_STATUSES` の全キーを 0 で初期化して返すため、
+    クライアントは存在チェックなしで各ステータスにアクセスできる。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
+
+    records = store.filter(
+        service=service, status=status, since=since, until=until, q=q_value,
+    )
+    by_status: dict[str, int] = {s: 0 for s in ALLOWED_STATUSES}
+    for r in records:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    return {"total": len(records), "by_status": by_status}
+
+
 @app.get("/metrics/services")
 def list_services(
     service: str | None = Query(

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1324,3 +1324,110 @@ def test_list_services_q_combined_with_service_filter():
 def test_list_services_q_blank_returns_400():
     resp = client.get("/metrics/services?q=%20%20")
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /metrics/count
+# ---------------------------------------------------------------------------
+
+
+def _seed_for_count():
+    """各ステータスを混ぜたサンプルレコードを投入する。"""
+    samples = [
+        ("api", "healthy", 10.0, 100.0),
+        ("api", "healthy", 12.0, 110.0),
+        ("api", "unhealthy", 200.0, 120.0),
+        ("db", "healthy", 5.0, 130.0),
+        ("db", "degraded", 80.0, 140.0),
+        ("worker", "unknown", 0.0, 150.0),
+    ]
+    for service, status, rt, ts in samples:
+        client.post(
+            "/metrics",
+            json={
+                "service": service, "status": status,
+                "response_time_ms": rt, "timestamp": ts,
+            },
+        )
+
+
+def test_count_empty_store():
+    resp = client.get("/metrics/count")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    # 全ステータスのキーが 0 で初期化されていること（クライアントの存在チェック不要）
+    assert data["by_status"] == {
+        "healthy": 0, "unhealthy": 0, "degraded": 0, "unknown": 0,
+    }
+
+
+def test_count_all_records():
+    _seed_for_count()
+    resp = client.get("/metrics/count")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 6
+    assert data["by_status"] == {
+        "healthy": 3, "unhealthy": 1, "degraded": 1, "unknown": 1,
+    }
+
+
+def test_count_filtered_by_service():
+    _seed_for_count()
+    resp = client.get("/metrics/count?service=api")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["by_status"]["healthy"] == 2
+    assert data["by_status"]["unhealthy"] == 1
+    assert data["by_status"]["degraded"] == 0
+    assert data["by_status"]["unknown"] == 0
+
+
+def test_count_filtered_by_status():
+    _seed_for_count()
+    resp = client.get("/metrics/count?status=healthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    # status 絞り込み後でも by_status はキーを全て含む
+    assert data["by_status"]["healthy"] == 3
+    assert data["by_status"]["unhealthy"] == 0
+
+
+def test_count_filtered_by_time_range():
+    _seed_for_count()
+    resp = client.get("/metrics/count?since=110&until=140")
+    assert resp.status_code == 200
+    data = resp.json()
+    # ts=110,120,130,140 → 4 件
+    assert data["total"] == 4
+
+
+def test_count_q_substring_case_insensitive():
+    _seed_for_count()
+    resp = client.get("/metrics/count?q=API")
+    assert resp.status_code == 200
+    data = resp.json()
+    # service=api のレコード 3 件のみ
+    assert data["total"] == 3
+    assert data["by_status"]["healthy"] == 2
+    assert data["by_status"]["unhealthy"] == 1
+
+
+def test_count_invalid_time_range_returns_400():
+    resp = client.get("/metrics/count?since=200&until=100")
+    assert resp.status_code == 400
+    assert "since" in resp.json()["detail"]
+
+
+def test_count_blank_q_returns_400():
+    resp = client.get("/metrics/count?q=%20%20")
+    assert resp.status_code == 400
+
+
+def test_count_invalid_status_returns_422():
+    # FastAPI の Query Literal 検査により未知 status は 422 になる
+    resp = client.get("/metrics/count?status=bogus")
+    assert resp.status_code == 422

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -450,6 +450,66 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("GET /api/metrics/count", () => {
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/count");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("forwards filter params and returns count payload", async () => {
+      const spy = jest.spyOn(axios, "get").mockResolvedValueOnce({
+        status: 200,
+        data: {
+          total: 3,
+          by_status: { healthy: 2, unhealthy: 1, degraded: 0, unknown: 0 },
+        },
+      } as never);
+      const res = await request(app).get(
+        "/api/metrics/count?service=web&status=healthy&since=1700000000&until=1800000000&q=web",
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(3);
+      expect(res.body.by_status.healthy).toBe(2);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/count");
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("status=healthy");
+      expect(calledUrl).toContain("since=1700000000");
+      expect(calledUrl).toContain("until=1800000000");
+      expect(calledUrl).toContain("q=web");
+      spy.mockRestore();
+    });
+
+    it("does not forward unrelated params (limit/offset/sort)", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { total: 0, by_status: {} } } as never);
+      const res = await request(app).get(
+        "/api/metrics/count?limit=10&offset=5&sort=service",
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("limit=");
+      expect(calledUrl).not.toContain("offset=");
+      expect(calledUrl).not.toContain("sort=");
+      spy.mockRestore();
+    });
+
+    it("propagates 4xx from analytics on invalid time range", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        data: { detail: "since must be less than or equal to until" },
+      } as never;
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/count?since=200&until=100");
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toContain("since");
+      spy.mockRestore();
+    });
+  });
+
   describe("404 handler", () => {
     it("returns 404 for unknown routes", async () => {
       const res = await request(app).get("/unknown");

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -99,6 +99,16 @@ app.get("/api/metrics/overview", (req: Request, res: Response) =>
   ),
 );
 
+app.get("/api/metrics/count", (req: Request, res: Response) =>
+  proxyAnalyticsGet(
+    req,
+    res,
+    "/metrics/count",
+    ["service", "status", "since", "until", "q"],
+    "count",
+  ),
+);
+
 app.get("/api/metrics/services", (req: Request, res: Response) =>
   proxyAnalyticsGet(
     req,


### PR DESCRIPTION
## 変更概要

- analytics-api に `GET /metrics/count` を追加。`/metrics` と同じフィルタ（`service`, `status`, `since`, `until`, `q`）を受け取り、件数とステータス別内訳のみを返す。
- レスポンス形状: `{total, by_status: {healthy, unhealthy, degraded, unknown}}`。`by_status` は全ステータスを 0 で初期化するため、クライアントは存在チェックなしでキーを参照できる。
- api-gateway に対応する `GET /api/metrics/count` を追加。既存の `proxyAnalyticsGet` ヘルパでフィルタクエリを上流に転送する。
- 既存のバリデーション（`since>until` の検査、`q` の trim・上限長、非有限値の拒否）を踏襲。
- レコード本体をシリアライズしないため、バッジ表示・ページャー初期化など件数のみが必要な UI で転送量と CPU を抑えられる。

Closes #67

## 動作確認手順

```bash
# analytics-api 単体
cd analytics-api
pip install -r requirements-dev.txt -r requirements.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v  # 全 132 件パス（既存 123 + 新規 9）

# api-gateway 単体
cd api-gateway
npm ci
npm run lint
npm test  # 全 40 件パス（既存 36 + 新規 4）
```

## サンプル呼び出し

```bash
$ curl 'http://localhost:8001/metrics/count?service=api'
{"total": 3, "by_status": {"healthy": 2, "unhealthy": 1, "degraded": 0, "unknown": 0}}

$ curl 'http://localhost:8000/api/metrics/count?status=healthy&since=1700000000'
{"total": 42, "by_status": {"healthy": 42, "unhealthy": 0, "degraded": 0, "unknown": 0}}
```