### PR TITLE
feat(analytics-api): /metrics/services に latest_response_ms を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -713,6 +713,7 @@ def list_services(
                 "first_seen": r.timestamp,
                 "last_seen": r.timestamp,
                 "latest_status": r.status,
+                "latest_response_ms": round(r.response_time_ms, 2),
             }
             continue
         existing["total_checks"] += 1
@@ -722,6 +723,7 @@ def list_services(
         if r.timestamp >= existing["last_seen"]:
             existing["last_seen"] = r.timestamp
             existing["latest_status"] = r.status
+            existing["latest_response_ms"] = round(r.response_time_ms, 2)
 
     # uptime_pct は集計確定後に一度だけ計算する（小数点 2 桁丸め）
     for s in by_service.values():

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -761,8 +761,11 @@ def test_list_services_distinct_aggregation():
     assert by_name["web"]["first_seen"] == 100.0
     assert by_name["web"]["last_seen"] == 200.0
     assert by_name["web"]["latest_status"] == "unhealthy"
+    # latest_response_ms は last_seen 時点（timestamp=200.0）の観測値
+    assert by_name["web"]["latest_response_ms"] == 2.0
     assert by_name["db"]["total_checks"] == 1
     assert by_name["db"]["latest_status"] == "healthy"
+    assert by_name["db"]["latest_response_ms"] == 3.0
 
 
 def test_list_services_default_sorted_by_service_asc():
@@ -1431,3 +1434,39 @@ def test_count_invalid_status_returns_422():
     # FastAPI の Query Literal 検査により未知 status は 422 になる
     resp = client.get("/metrics/count?status=bogus")
     assert resp.status_code == 422
+
+
+def test_list_services_latest_response_ms_single_observation():
+    # 単一観測なら、その観測の response_time_ms が latest_response_ms になる
+    client.post("/metrics", json={
+        "service": "single", "status": "healthy", "response_time_ms": 12.5, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services")
+    services = resp.json()["services"]
+    assert services[0]["service"] == "single"
+    assert services[0]["latest_response_ms"] == 12.5
+
+
+def test_list_services_latest_response_ms_older_observation_does_not_overwrite():
+    # 後から古いタイムスタンプの観測を追加しても、latest_response_ms は更新されない
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 50.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 999.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services")
+    by_name = {s["service"]: s for s in resp.json()["services"]}
+    assert by_name["web"]["latest_response_ms"] == 50.0
+    assert by_name["web"]["latest_status"] == "healthy"
+
+
+def test_list_services_latest_response_ms_is_rounded():
+    # 内部値は小数点 2 桁に丸めて返す（avg_response_ms 等と同じ流儀）
+    client.post("/metrics", json={
+        "service": "round", "status": "healthy",
+        "response_time_ms": 12.345678, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services")
+    services = resp.json()["services"]
+    assert services[0]["latest_response_ms"] == 12.35


### PR DESCRIPTION
## 変更概要

- `analytics-api/main.py` の `list_services` で、各サービスの集計辞書に `latest_response_ms` を追加（`last_seen` 観測時の `response_time_ms` を小数点 2 桁丸めで保持）。
- 新規挿入時は最初の観測値で初期化、`r.timestamp >= existing['last_seen']` の枝で `latest_status` と一緒に更新。
- 追加フィールドのみで既存フィールドは不変なため後方互換。
- `test_main.py`:
  - 既存の `test_list_services_distinct_aggregation` に `latest_response_ms` の assertion を追加
  - 新規 3 ケース追加（単一観測 / 古い観測で上書きされない / 小数点 2 桁丸め）

## 対応 Issue

Closes #69

## 動作確認手順

- `cd analytics-api && pip install -r requirements-dev.txt`
- `flake8 --max-line-length=120 --exclude=__pycache__ main.py`（ローカル実行済み・OK）
- `pytest -v`（ローカル実行済み・135 件 全 pass / 既存 132 + 新規 3）
- `GET /metrics/services` のレスポンスに `latest_response_ms` が含まれること