### PR TITLE
feat: 単一サービス詳細エンドポイント /metrics/services/{name} を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -218,6 +218,60 @@ class MetricsStore:
             }
         return result
 
+    def service_detail(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> dict | None:
+        """単一サービスの集約結果を返す。レコードが 1 件も無ければ None。
+
+        `summary()` の単一サービス相当の数値 (percentile 含む) に、
+        `list_services()` 由来の `latest_*` / `first_seen` / `last_seen` を
+        合わせて 1 オブジェクトで返す。ダッシュボードのサービス詳細画面の
+        単一エンドポイント化を意図している。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        if not records_snapshot:
+            return None
+
+        total = len(records_snapshot)
+        healthy = 0
+        times: list[float] = []
+        first_seen: float | None = None
+        last_seen: float | None = None
+        latest_status = ""
+        latest_response_ms = 0.0
+        for r in records_snapshot:
+            if r.status == "healthy":
+                healthy += 1
+            times.append(r.response_time_ms)
+            if first_seen is None or r.timestamp < first_seen:
+                first_seen = r.timestamp
+            if last_seen is None or r.timestamp >= last_seen:
+                last_seen = r.timestamp
+                latest_status = r.status
+                latest_response_ms = r.response_time_ms
+
+        sorted_times = sorted(times)
+        avg = sum(times) / total
+        return {
+            "service": service,
+            "total_checks": total,
+            "healthy_checks": healthy,
+            "uptime_pct": round(healthy / total * 100, 2),
+            "first_seen": first_seen,
+            "last_seen": last_seen,
+            "latest_status": latest_status,
+            "latest_response_ms": round(latest_response_ms, 2),
+            "avg_response_ms": round(avg, 2),
+            "min_response_ms": round(sorted_times[0], 2),
+            "max_response_ms": round(sorted_times[-1], 2),
+            "p50_response_ms": round(_percentile(sorted_times, 50), 2),
+            "p95_response_ms": round(_percentile(sorted_times, 95), 2),
+            "p99_response_ms": round(_percentile(sorted_times, 99), 2),
+        }
+
     def overview(
         self,
         service: str | None = None,
@@ -749,6 +803,55 @@ def list_services(
         "order": order,
         "services": page,
     }
+
+
+@app.get("/metrics/services/{service_name}")
+def get_service_detail(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+):
+    """単一サービスの詳細集計を返す。データが無ければ 404。
+
+    `/metrics/services?service=X` は単一要素の配列を返すため UI 側で unwrap
+    が必要だったが、こちらは単一オブジェクトを返す。`latest_*` と
+    percentile (p50/p95/p99) を同時に返すため、サービス詳細画面で 1
+    リクエストにまとめられる。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    detail = store.service_detail(service=normalized, since=since, until=until)
+    if detail is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return detail
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1470,3 +1470,96 @@ def test_list_services_latest_response_ms_is_rounded():
     resp = client.get("/metrics/services")
     services = resp.json()["services"]
     assert services[0]["latest_response_ms"] == 12.35
+
+
+def test_get_service_detail_404_when_no_data():
+    resp = client.get("/metrics/services/unknown")
+    assert resp.status_code == 404
+    assert "unknown" in resp.json()["detail"]
+
+
+def test_get_service_detail_returns_aggregate():
+    for i, rt in enumerate([10.0, 30.0, 20.0, 40.0]):
+        client.post("/metrics", json={
+            "service": "api", "status": "healthy" if i % 2 == 0 else "unhealthy",
+            "response_time_ms": rt, "timestamp": 100.0 + i,
+        })
+    resp = client.get("/metrics/services/api")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "api"
+    assert data["total_checks"] == 4
+    assert data["healthy_checks"] == 2
+    assert data["uptime_pct"] == 50.0
+    assert data["min_response_ms"] == 10.0
+    assert data["max_response_ms"] == 40.0
+    assert data["avg_response_ms"] == 25.0
+    # 最新観測は timestamp=103 のもの: rt=40.0, status=unhealthy
+    assert data["latest_status"] == "unhealthy"
+    assert data["latest_response_ms"] == 40.0
+    assert data["first_seen"] == 100.0
+    assert data["last_seen"] == 103.0
+    # percentile keys must exist
+    assert "p50_response_ms" in data
+    assert "p95_response_ms" in data
+    assert "p99_response_ms" in data
+
+
+def test_get_service_detail_filters_other_services():
+    client.post("/metrics", json={
+        "service": "api", "status": "healthy", "response_time_ms": 10.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "unhealthy", "response_time_ms": 500.0,
+    })
+    resp = client.get("/metrics/services/api")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "api"
+    assert data["total_checks"] == 1
+    assert data["healthy_checks"] == 1
+
+
+def test_get_service_detail_strips_whitespace():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 10.0,
+    })
+    resp = client.get("/metrics/services/%20web%20")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "web"
+
+
+def test_get_service_detail_rejects_blank_name():
+    resp = client.get("/metrics/services/%20%20")
+    assert resp.status_code == 400
+
+
+def test_get_service_detail_rejects_overlong_name():
+    long_name = "x" * 200
+    resp = client.get(f"/metrics/services/{long_name}")
+    assert resp.status_code == 400
+
+
+def test_get_service_detail_time_range_filter():
+    for ts, rt in [(100.0, 10.0), (200.0, 20.0), (300.0, 30.0)]:
+        client.post("/metrics", json={
+            "service": "web", "status": "healthy", "response_time_ms": rt, "timestamp": ts,
+        })
+    resp = client.get("/metrics/services/web?since=150&until=250")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_checks"] == 1
+    assert data["avg_response_ms"] == 20.0
+
+
+def test_get_service_detail_since_greater_than_until_rejected():
+    resp = client.get("/metrics/services/web?since=300&until=100")
+    assert resp.status_code == 400
+
+
+def test_get_service_detail_404_when_filter_excludes_all():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 10.0, "timestamp": 50.0,
+    })
+    resp = client.get("/metrics/services/web?since=100")
+    assert resp.status_code == 404

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -256,6 +256,74 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("GET /api/metrics/services/:name", () => {
+    it("forwards to /metrics/services/{name} with url-encoded path", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { service: "web", total_checks: 3 },
+        } as never);
+      const res = await request(app).get("/api/metrics/services/web");
+      expect(res.status).toBe(200);
+      expect(res.body.service).toBe("web");
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/services/web");
+      spy.mockRestore();
+    });
+
+    it("forwards since/until query params", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { service: "web" } } as never);
+      const res = await request(app).get(
+        "/api/metrics/services/web?since=100&until=200"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("since=100");
+      expect(calledUrl).toContain("until=200");
+      spy.mockRestore();
+    });
+
+    it("propagates 404 from analytics when no data", async () => {
+      const err = new AxiosError("Not Found");
+      err.response = {
+        status: 404,
+        statusText: "Not Found",
+        headers: {},
+        config: {} as never,
+        data: { detail: "No metrics found for service 'web'" },
+      };
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/services/web");
+      expect(res.status).toBe(404);
+      expect(res.body.detail).toContain("No metrics");
+      spy.mockRestore();
+    });
+
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/services/web");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("url-encodes service names with special characters", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({ status: 200, data: { service: "a/b" } } as never);
+      // request library does the path-encoding on its end; route param will be 'a/b' decoded
+      const res = await request(app).get(
+        "/api/metrics/services/" + encodeURIComponent("a b")
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      // a%20b 形式で送られる（encodeURIComponent の挙動）
+      expect(calledUrl).toContain("/metrics/services/a%20b");
+      spy.mockRestore();
+    });
+  });
+
   describe("POST /api/metrics", () => {
     it("returns 502 when analytics is down", async () => {
       const res = await request(app)

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -119,6 +119,20 @@ app.get("/api/metrics/services", (req: Request, res: Response) =>
   ),
 );
 
+// 単一サービスの詳細を返すエンドポイント。analytics-api 側で 404 が返るため、
+// proxy 経由でもそのまま 404 を伝播する。
+app.get(
+  "/api/metrics/services/:name",
+  (req: Request<{ name: string }>, res: Response) =>
+    proxyAnalyticsGet(
+      req,
+      res,
+      `/metrics/services/${encodeURIComponent(req.params.name)}`,
+      ["since", "until"],
+      "service-detail",
+    ),
+);
+
 app.post("/api/metrics", async (req: Request, res: Response) => {
   try {
     const resp = await axios.post(`${ANALYTICS_URL}/metrics`, req.body, { timeout: PROXY_TIMEOUT });


### PR DESCRIPTION
## 変更概要

- `analytics-api` に `GET /metrics/services/{service_name}` を新設
  - `total_checks`/`healthy_checks`/`uptime_pct`/`first_seen`/`last_seen`/`latest_status`/`latest_response_ms` + `avg/min/max` + `p50/p95/p99` を 1 オブジェクトで返却
  - データ無し → 404、`since`/`until` クエリ対応、`service_name` の strip/長さチェック
- `api-gateway` に `GET /api/metrics/services/:name` のプロキシを追加
  - `since`/`until` を上流へ転送、`encodeURIComponent` でパスを安全化
  - 上流 404 はそのまま伝播
- analytics-api: 8 件、api-gateway: 5 件のテストを追加（合計 144 + 50 = 194 件全てパス）

Closes #71

## 動作確認手順

```
# analytics-api
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v

# api-gateway
cd api-gateway
npm ci && npm run lint && npm test
```