### PR TITLE
feat: 時系列バケット集計エンドポイント /metrics/timeseries の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ npm start
 | GET | `/api/metrics/summary` | Per-service uptime and response time summary（`?q=` で service 名部分一致検索） |
 | GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API、`?q=` で部分一致検索） |
 | GET | `/api/metrics/services` | サービス一覧（`?q=` で部分一致検索、`?sort=` / `?order=` / `?limit=` / `?offset=`） |
+| GET | `/api/metrics/timeseries` | 時系列バケット集計（`?bucket_seconds=` でバケット幅を指定、既定 60 秒） |
 | POST | `/api/metrics` | Record a metric (proxy to Analytics API) |
 | GET | `/api/check` | Run health checks on all targets (proxy to Checker) |
 | GET | `/api/status` | Aggregated health status of all internal services |
@@ -168,6 +169,7 @@ Response:
 | GET | `/metrics/summary` | Per-service summary statistics |
 | GET | `/metrics/overview` | 全レコードを 1 つに集約したトップレベル稼働サマリ（`?service=` / `?status=` / `?since=` / `?until=`） |
 | GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
+| GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 
 #### Delete Metrics
 
@@ -274,6 +276,45 @@ curl "http://localhost:8001/metrics/services?sort=healthy_checks&order=desc"
 ```
 
 `uptime_pct` は `healthy_checks / total_checks * 100`（小数点 2 桁丸め、`total_checks == 0` の場合 `0`）。
+
+#### Get Timeseries
+
+`/metrics/timeseries` はフィルタ後のレコードを `bucket_seconds` 秒幅の半開区間 `[bucket_start, bucket_start + bucket_seconds)` でグルーピングし、バケット単位の集計を返す。ダッシュボードの時系列チャートなど、サーバ側でビニング済みのデータが欲しいケース向け。
+
+```bash
+# 既定 (60秒バケット)
+curl http://localhost:8001/metrics/timeseries
+
+# 5分バケット + service / status / since の絞り込み
+curl "http://localhost:8001/metrics/timeseries?bucket_seconds=300&service=web&status=healthy&since=1700000000"
+```
+
+`bucket_seconds` は `1`〜`86400`（1秒〜1日）。レコードのない時刻のバケットは返さない（スパース表現）。並び順は `bucket_start` 昇順。
+
+レスポンス例:
+
+```json
+{
+  "bucket_seconds": 60,
+  "count": 2,
+  "buckets": [
+    {
+      "bucket_start": 1700000000.0,
+      "total": 3,
+      "by_status": {"healthy": 2, "unhealthy": 1, "degraded": 0, "unknown": 0},
+      "avg_response_ms": 30.0
+    },
+    {
+      "bucket_start": 1700000060.0,
+      "total": 1,
+      "by_status": {"healthy": 1, "unhealthy": 0, "degraded": 0, "unknown": 0},
+      "avg_response_ms": 70.0
+    }
+  ]
+}
+```
+
+`by_status` は `ALLOWED_STATUSES` の全キーを 0 初期化したマップで返るため、クライアントは存在チェックなしで参照できる。
 
 ### Health Checker (port 8002)
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -272,6 +272,56 @@ class MetricsStore:
             "p99_response_ms": round(_percentile(sorted_times, 99), 2),
         }
 
+    def timeseries(
+        self,
+        bucket_seconds: int,
+        service: str | None = None,
+        status: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+        q: str | None = None,
+    ) -> list[dict]:
+        """フィルタ後のレコードを `bucket_seconds` 秒幅の半開区間バケットに集約する。
+
+        各バケットは `[bucket_start, bucket_start + bucket_seconds)` に属する観測を対象に、
+        総件数 `total` / ステータス内訳 `by_status` / 平均応答時間 `avg_response_ms` を返す。
+        レコードのない時刻のバケットは結果に含めない（スパース）。
+        並び順は `bucket_start` の昇順。`by_status` は `ALLOWED_STATUSES` の全キーを
+        0 初期化したマップで返すため、クライアントは存在チェックなしで参照できる。
+        """
+        records_snapshot = self.filter(
+            service=service, status=status, since=since, until=until, q=q,
+        )
+        buckets: dict[int, dict] = {}
+        for r in records_snapshot:
+            # 整数演算でバケット境界を求める。負の timestamp は通常起こりえないが、
+            # 万一来ても `int(floor(...))` 相当として正しく丸まる。
+            bucket_start = int(r.timestamp // bucket_seconds) * bucket_seconds
+            b = buckets.get(bucket_start)
+            if b is None:
+                b = {
+                    "total": 0,
+                    "by_status": {s: 0 for s in ALLOWED_STATUSES},
+                    "times": [],
+                }
+                buckets[bucket_start] = b
+            b["total"] += 1
+            b["by_status"][r.status] = b["by_status"].get(r.status, 0) + 1
+            b["times"].append(r.response_time_ms)
+
+        result: list[dict] = []
+        for bucket_start in sorted(buckets.keys()):
+            b = buckets[bucket_start]
+            times = b["times"]
+            avg = sum(times) / len(times) if times else 0.0
+            result.append({
+                "bucket_start": float(bucket_start),
+                "total": b["total"],
+                "by_status": b["by_status"],
+                "avg_response_ms": round(avg, 2),
+            })
+        return result
+
     def overview(
         self,
         service: str | None = None,
@@ -684,6 +734,65 @@ def get_metrics_count(
     for r in records:
         by_status[r.status] = by_status.get(r.status, 0) + 1
     return {"total": len(records), "by_status": by_status}
+
+
+@app.get("/metrics/timeseries")
+def get_timeseries(
+    bucket_seconds: int = Query(
+        default=60,
+        ge=1,
+        le=86400,
+        description="バケット幅（秒）。1秒〜1日（86400秒）の範囲で指定。",
+    ),
+    service: str | None = None,
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）のレコードに絞り込む",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）のレコードに絞り込む",
+    ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
+):
+    """フィルタ条件に合致するレコードを `bucket_seconds` 秒幅の時系列バケットに集約して返す。
+
+    各バケットは `[bucket_start, bucket_start + bucket_seconds)` の半開区間で、
+    観測のないバケットは結果に含めない（スパース表現）。並び順は `bucket_start` 昇順。
+    ダッシュボードの時系列チャートなど、サーバ側でビニング済みのデータを必要とする
+    用途を想定している。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
+
+    buckets = store.timeseries(
+        bucket_seconds=bucket_seconds,
+        service=service, status=status, since=since, until=until, q=q_value,
+    )
+    return {
+        "bucket_seconds": bucket_seconds,
+        "count": len(buckets),
+        "buckets": buckets,
+    }
 
 
 @app.get("/metrics/services")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1563,3 +1563,200 @@ def test_get_service_detail_404_when_filter_excludes_all():
     })
     resp = client.get("/metrics/services/web?since=100")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /metrics/timeseries — 時系列バケット集計
+# ---------------------------------------------------------------------------
+
+
+def test_timeseries_empty_returns_no_buckets():
+    resp = client.get("/metrics/timeseries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bucket_seconds"] == 60
+    assert data["count"] == 0
+    assert data["buckets"] == []
+
+
+def test_timeseries_default_bucket_size_groups_within_minute():
+    # 60 秒幅（default）。バケット [1020, 1080) に 3 件、[1080, 1140) に 1 件。
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 10.0, "timestamp": 1020.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 30.0, "timestamp": 1050.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 50.0, "timestamp": 1079.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 70.0, "timestamp": 1080.0,
+    })
+    resp = client.get("/metrics/timeseries")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bucket_seconds"] == 60
+    assert data["count"] == 2
+    buckets = data["buckets"]
+    assert buckets[0]["bucket_start"] == 1020.0
+    assert buckets[0]["total"] == 3
+    assert buckets[0]["by_status"]["healthy"] == 2
+    assert buckets[0]["by_status"]["unhealthy"] == 1
+    assert buckets[0]["avg_response_ms"] == 30.0  # (10+30+50)/3
+    assert buckets[1]["bucket_start"] == 1080.0
+    assert buckets[1]["total"] == 1
+    assert buckets[1]["avg_response_ms"] == 70.0
+
+
+def test_timeseries_custom_bucket_size():
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 109.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 110.0,
+    })
+    resp = client.get("/metrics/timeseries?bucket_seconds=10")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bucket_seconds"] == 10
+    assert data["count"] == 2
+    assert data["buckets"][0]["bucket_start"] == 100.0
+    assert data["buckets"][0]["total"] == 2
+    assert data["buckets"][1]["bucket_start"] == 110.0
+    assert data["buckets"][1]["total"] == 1
+
+
+def test_timeseries_by_status_includes_all_keys():
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/timeseries?bucket_seconds=60")
+    data = resp.json()
+    by_status = data["buckets"][0]["by_status"]
+    assert set(by_status.keys()) == {"healthy", "unhealthy", "degraded", "unknown"}
+    assert by_status["healthy"] == 1
+    assert by_status["unhealthy"] == 0
+    assert by_status["degraded"] == 0
+    assert by_status["unknown"] == 0
+
+
+def test_timeseries_sparse_skips_empty_buckets():
+    # 60 秒バケットで時刻 60 と時刻 600 にレコード → 中間バケットは含まれない
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 60.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 600.0,
+    })
+    resp = client.get("/metrics/timeseries?bucket_seconds=60")
+    data = resp.json()
+    assert data["count"] == 2
+    starts = [b["bucket_start"] for b in data["buckets"]]
+    assert starts == [60.0, 600.0]
+
+
+def test_timeseries_filter_by_service():
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 10.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "b", "status": "healthy", "response_time_ms": 20.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/timeseries?service=a&bucket_seconds=60")
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["buckets"][0]["total"] == 1
+    assert data["buckets"][0]["avg_response_ms"] == 10.0
+
+
+def test_timeseries_filter_by_status():
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 10.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "unhealthy", "response_time_ms": 20.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/timeseries?status=healthy&bucket_seconds=60")
+    data = resp.json()
+    assert data["buckets"][0]["total"] == 1
+    assert data["buckets"][0]["by_status"]["healthy"] == 1
+    assert data["buckets"][0]["by_status"]["unhealthy"] == 0
+
+
+def test_timeseries_filter_by_since_until():
+    for ts in (50.0, 100.0, 150.0, 200.0):
+        client.post("/metrics", json={
+            "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": ts,
+        })
+    resp = client.get("/metrics/timeseries?since=100&until=150&bucket_seconds=60")
+    data = resp.json()
+    total = sum(b["total"] for b in data["buckets"])
+    assert total == 2
+
+
+def test_timeseries_filter_by_q_partial_match():
+    client.post("/metrics", json={
+        "service": "frontend-web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    client.post("/metrics", json={
+        "service": "backend-api", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/timeseries?q=front&bucket_seconds=60")
+    data = resp.json()
+    assert data["buckets"][0]["total"] == 1
+
+
+def test_timeseries_rejects_bucket_too_small():
+    resp = client.get("/metrics/timeseries?bucket_seconds=0")
+    assert resp.status_code == 422
+
+
+def test_timeseries_rejects_negative_bucket():
+    resp = client.get("/metrics/timeseries?bucket_seconds=-1")
+    assert resp.status_code == 422
+
+
+def test_timeseries_rejects_bucket_too_large():
+    resp = client.get("/metrics/timeseries?bucket_seconds=86401")
+    assert resp.status_code == 422
+
+
+def test_timeseries_rejects_since_greater_than_until():
+    resp = client.get("/metrics/timeseries?since=200&until=100")
+    assert resp.status_code == 400
+
+
+def test_timeseries_rejects_blank_q():
+    resp = client.get("/metrics/timeseries?q=%20%20%20")
+    assert resp.status_code == 400
+
+
+def test_timeseries_avg_response_ms_rounded_to_two_decimals():
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 2.0, "timestamp": 2.0,
+    })
+    client.post("/metrics", json={
+        "service": "a", "status": "healthy", "response_time_ms": 3.0, "timestamp": 3.0,
+    })
+    # (1+2+3)/3 = 2.0
+    resp = client.get("/metrics/timeseries?bucket_seconds=60")
+    data = resp.json()
+    assert data["buckets"][0]["avg_response_ms"] == 2.0
+
+
+def test_timeseries_buckets_sorted_ascending():
+    # ランダム順で投入してもバケットは昇順で返るべき
+    for ts in (300.0, 100.0, 500.0, 200.0):
+        client.post("/metrics", json={
+            "service": "a", "status": "healthy", "response_time_ms": 1.0, "timestamp": ts,
+        })
+    resp = client.get("/metrics/timeseries?bucket_seconds=60")
+    starts = [b["bucket_start"] for b in resp.json()["buckets"]]
+    assert starts == sorted(starts)

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -621,6 +621,101 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("GET /api/metrics/timeseries", () => {
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/timeseries");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("forwards filter params including bucket_seconds", async () => {
+      const spy = jest.spyOn(axios, "get").mockResolvedValueOnce({
+        status: 200,
+        data: {
+          bucket_seconds: 60,
+          count: 1,
+          buckets: [
+            {
+              bucket_start: 1700000000.0,
+              total: 2,
+              by_status: { healthy: 2, unhealthy: 0, degraded: 0, unknown: 0 },
+              avg_response_ms: 12.34,
+            },
+          ],
+        },
+      } as never);
+      const res = await request(app).get(
+        "/api/metrics/timeseries?service=web&status=healthy&since=1700000000&until=1800000000&q=web&bucket_seconds=60",
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.bucket_seconds).toBe(60);
+      expect(res.body.count).toBe(1);
+      expect(res.body.buckets[0].total).toBe(2);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/metrics/timeseries");
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("status=healthy");
+      expect(calledUrl).toContain("since=1700000000");
+      expect(calledUrl).toContain("until=1800000000");
+      expect(calledUrl).toContain("q=web");
+      expect(calledUrl).toContain("bucket_seconds=60");
+      spy.mockRestore();
+    });
+
+    it("does not forward unrelated params (limit/offset/sort)", async () => {
+      const spy = jest.spyOn(axios, "get").mockResolvedValueOnce({
+        status: 200,
+        data: { bucket_seconds: 60, count: 0, buckets: [] },
+      } as never);
+      const res = await request(app).get(
+        "/api/metrics/timeseries?limit=10&offset=5&sort=timestamp&order=desc",
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("limit=");
+      expect(calledUrl).not.toContain("offset=");
+      expect(calledUrl).not.toContain("sort=");
+      expect(calledUrl).not.toContain("order=");
+      spy.mockRestore();
+    });
+
+    it("strips empty bucket_seconds (lets analytics default kick in)", async () => {
+      const spy = jest.spyOn(axios, "get").mockResolvedValueOnce({
+        status: 200,
+        data: { bucket_seconds: 60, count: 0, buckets: [] },
+      } as never);
+      await request(app).get("/api/metrics/timeseries?bucket_seconds=");
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("bucket_seconds=");
+      spy.mockRestore();
+    });
+
+    it("propagates 422 from analytics on invalid bucket_seconds", async () => {
+      const err = new AxiosError("Unprocessable Entity");
+      err.response = {
+        status: 422,
+        data: { detail: [{ msg: "ensure this value is greater than or equal to 1" }] },
+      } as never;
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/timeseries?bucket_seconds=0");
+      expect(res.status).toBe(422);
+      spy.mockRestore();
+    });
+
+    it("propagates 400 from analytics when since > until", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        data: { detail: "since must be less than or equal to until" },
+      } as never;
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/timeseries?since=200&until=100");
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toContain("since");
+      spy.mockRestore();
+    });
+  });
+
   describe("404 handler", () => {
     it("returns 404 for unknown routes", async () => {
       const res = await request(app).get("/unknown");

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -161,6 +161,18 @@ app.get("/api/metrics/services", (req: Request, res: Response) =>
   ),
 );
 
+// 時系列バケット集計エンドポイントを analytics-api にプロキシする。
+// allowedParams は analytics-api 側 `/metrics/timeseries` のクエリと一致させる。
+app.get("/api/metrics/timeseries", (req: Request, res: Response) =>
+  proxyAnalyticsGet(
+    req,
+    res,
+    "/metrics/timeseries",
+    ["service", "status", "since", "until", "q", "bucket_seconds"],
+    "timeseries",
+  ),
+);
+
 // 単一サービスの詳細を返すエンドポイント。analytics-api 側で 404 が返るため、
 // proxy 経由でもそのまま 404 を伝播する。
 app.get(


### PR DESCRIPTION
## 概要

- analytics-api に **`GET /metrics/timeseries`** を追加。フィルタ後のレコードを `bucket_seconds` 秒幅の半開区間バケットに集約し、`total` / `by_status` / `avg_response_ms` を返す
- api-gateway に **`GET /api/metrics/timeseries`** プロキシを追加（既存の `proxyAnalyticsGet` ヘルパを再利用）
- README にエンドポイント説明・レスポンス例を追記

Closes #75

## 仕様

- バケットは `[bucket_start, bucket_start + bucket_seconds)` の半開区間
- レコードのない時刻のバケットは返さない（スパース表現）
- 並び順は `bucket_start` 昇順
- `bucket_seconds` の許容範囲: `1`〜`86400`（1 秒〜1 日）。既定 60 秒
- `by_status` は `ALLOWED_STATUSES` (healthy/unhealthy/degraded/unknown) の全キーを 0 初期化
- 既存のフィルタ系と同じ `service` / `status` / `since` / `until` / `q` を受ける

## 動作確認

- [x] `analytics-api`: `flake8 --max-line-length=120 main.py` パス
- [x] `analytics-api`: `pytest -v` で **160 tests passed**（うち新規 timeseries テスト 16 件）
- [x] `api-gateway`: `npm run lint` パス
- [x] `api-gateway`: `npm test` で **54 tests passed**（うち新規 timeseries proxy テスト 6 件）
- [x] `health-checker`: `go test ./...` パス（変更なし）

## カバーするケース

### analytics-api 側
- 空ストア → `count=0`, `buckets=[]`
- バケット境界（60秒）またぎ / 内側
- カスタム `bucket_seconds`（例: 10秒）
- `by_status` が ALLOWED_STATUSES の全キーを含む
- スパース表現（中間バケットが含まれない）
- `service` / `status` / `since`/`until` / `q` フィルタ
- `bucket_seconds=0`, `bucket_seconds=-1`, `bucket_seconds=86401` → 422
- `since>until` → 400
- 空白のみの `q` → 400
- `avg_response_ms` 小数点2桁丸め
- ランダム順投入でも `bucket_start` 昇順で返る

### api-gateway 側
- 上流ダウン時 502
- 全パラメータの正常転送
- 関係ない `limit`/`offset`/`sort`/`order` を上流に転送しない
- 空文字の `bucket_seconds=` を除外して上流デフォルトに任せる
- 上流の 4xx (400/422) をそのまま伝播