### PR TITLE
feat(analytics-api): /metrics/services/names エンドポイントの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ npm start
 | GET | `/api/metrics/summary` | Per-service uptime and response time summary（`?q=` で service 名部分一致検索） |
 | GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API、`?q=` で部分一致検索） |
 | GET | `/api/metrics/services` | サービス一覧（`?q=` で部分一致検索、`?sort=` / `?order=` / `?limit=` / `?offset=`） |
+| GET | `/api/metrics/services/names` | distinct な service 名一覧のみを返す軽量エンドポイント（フィルタドロップダウン populate 用、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
 | GET | `/api/metrics/timeseries` | 時系列バケット集計（`?bucket_seconds=` でバケット幅を指定、既定 60 秒） |
 | POST | `/api/metrics` | Record a metric (proxy to Analytics API) |
 | GET | `/api/check` | Run health checks on all targets (proxy to Checker) |
@@ -169,6 +170,7 @@ Response:
 | GET | `/metrics/summary` | Per-service summary statistics |
 | GET | `/metrics/overview` | 全レコードを 1 つに集約したトップレベル稼働サマリ（`?service=` / `?status=` / `?since=` / `?until=`） |
 | GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
+| GET | `/metrics/services/names` | distinct な service 名のみを返す軽量エンドポイント（per-service 集計を行わずペイロード最小化、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
 | GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 
 #### Delete Metrics
@@ -276,6 +278,37 @@ curl "http://localhost:8001/metrics/services?sort=healthy_checks&order=desc"
 ```
 
 `uptime_pct` は `healthy_checks / total_checks * 100`（小数点 2 桁丸め、`total_checks == 0` の場合 `0`）。
+
+#### List Service Names Only
+
+`/metrics/services/names` は distinct な service 名のみを返す。`/metrics/services` のような per-service の uptime / first_seen / last_seen / percentile などフル集計を行わないため、フィルタドロップダウンの populate のように「名前だけ欲しい」用途で /metrics/services よりも小さなペイロード・低コストで応答できる。
+
+```bash
+# 全 service 名（昇順）
+curl http://localhost:8001/metrics/services/names
+
+# 名前に "api" を含むものだけ（大文字小文字無視）
+curl "http://localhost:8001/metrics/services/names?q=api"
+
+# 名前降順 + ページング
+curl "http://localhost:8001/metrics/services/names?order=desc&limit=10&offset=0"
+
+# 直近 1 時間に観測された service 名のみ
+curl "http://localhost:8001/metrics/services/names?since=$(($(date +%s) - 3600))"
+```
+
+レスポンス例:
+
+```json
+{
+  "count": 3,
+  "total": 3,
+  "limit": 100,
+  "offset": 0,
+  "order": "asc",
+  "names": ["api-gateway", "billing", "user-service"]
+}
+```
 
 #### Get Timeseries
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -151,6 +151,22 @@ class MetricsStore:
             logger.info("Deleted %d records for service=%s", deleted, service)
         return deleted
 
+    def distinct_services(
+        self,
+        since: float | None = None,
+        until: float | None = None,
+        q: str | None = None,
+    ) -> list[str]:
+        """フィルタ後のレコードから重複排除した service 名一覧を返す（順不同）。
+
+        `/metrics/services` のような per-service 集計（uptime / first_seen /
+        last_seen / percentile 等）は一切行わないため、フィルタドロップダウンの
+        populate のような「名前だけ欲しい」場面で /metrics/services より小さな
+        ペイロード・低コストで応答できる。順序付けは呼び出し側で行う。
+        """
+        records_snapshot = self.filter(since=since, until=until, q=q)
+        return list({r.service for r in records_snapshot})
+
     def delete(self, service: str | None = None, before: float | None = None) -> int:
         """Delete records matching the given filters.
 
@@ -911,6 +927,73 @@ def list_services(
         "sort": sort,
         "order": order,
         "services": page,
+    }
+
+
+@app.get("/metrics/services/names")
+def list_service_names(
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみを対象にする",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみを対象にする",
+    ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する大文字小文字無視の部分一致検索",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="サービス名の並び順（asc / desc）",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+):
+    """フィルタ後のレコードに含まれる distinct な service 名一覧のみを返す軽量エンドポイント。
+
+    `/metrics/services` は per-service の uptime / first_seen / last_seen /
+    latest_status / percentile などフル集計を返すため、フィルタドロップダウンの
+    populate のように「名前だけ欲しい」用途では過剰。本エンドポイントは集計を
+    一切行わず、重複排除した service 名のみをサービス名昇順（または降順）に
+    並べてページネーションして返す。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+    q_value, q_err = _normalize_q_param(q)
+    if q_err is not None:
+        raise HTTPException(status_code=400, detail=q_err)
+
+    names = store.distinct_services(since=since, until=until, q=q_value)
+    names.sort(reverse=(order == "desc"))
+    total = len(names)
+    page = names[offset:offset + limit]
+    return {
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "order": order,
+        "names": page,
     }
 
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1760,3 +1760,120 @@ def test_timeseries_buckets_sorted_ascending():
     resp = client.get("/metrics/timeseries?bucket_seconds=60")
     starts = [b["bucket_start"] for b in resp.json()["buckets"]]
     assert starts == sorted(starts)
+
+
+# ---------------------------------------------------------------------------
+# GET /metrics/services/names — distinct service 名のみを返す軽量エンドポイント
+# ---------------------------------------------------------------------------
+
+
+def test_service_names_empty_store():
+    resp = client.get("/metrics/services/names")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "count": 0,
+        "total": 0,
+        "limit": data["limit"],
+        "offset": 0,
+        "order": "asc",
+        "names": [],
+    }
+
+
+def test_service_names_distinct_and_sorted_asc():
+    # 同じ service を複数回投入しても 1 件にまとめられる、かつ昇順で返る
+    for svc in ("zeta", "alpha", "beta", "alpha", "beta"):
+        client.post("/metrics", json={
+            "service": svc, "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+        })
+    resp = client.get("/metrics/services/names")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["names"] == ["alpha", "beta", "zeta"]
+    assert data["total"] == 3
+    assert data["count"] == 3
+
+
+def test_service_names_order_desc():
+    for svc in ("alpha", "beta", "zeta"):
+        client.post("/metrics", json={
+            "service": svc, "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+        })
+    resp = client.get("/metrics/services/names?order=desc")
+    assert resp.status_code == 200
+    assert resp.json()["names"] == ["zeta", "beta", "alpha"]
+
+
+def test_service_names_pagination():
+    for svc in ("a", "b", "c", "d", "e"):
+        client.post("/metrics", json={
+            "service": svc, "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+        })
+    resp = client.get("/metrics/services/names?limit=2&offset=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["names"] == ["b", "c"]
+    assert data["count"] == 2
+    assert data["total"] == 5
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+
+
+def test_service_names_q_filter_case_insensitive():
+    for svc in ("api-gateway", "API-Worker", "user-service", "BillingAPI"):
+        client.post("/metrics", json={
+            "service": svc, "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+        })
+    resp = client.get("/metrics/services/names?q=api")
+    assert resp.status_code == 200
+    data = resp.json()
+    # "api" を含む 3 件のみ（大文字小文字無視）。元の表記は保たれる。
+    assert set(data["names"]) == {"api-gateway", "API-Worker", "BillingAPI"}
+    assert data["total"] == 3
+
+
+def test_service_names_q_blank_rejected():
+    resp = client.get("/metrics/services/names?q=%20%20")
+    assert resp.status_code == 400
+    assert "must not be blank" in resp.json()["detail"]
+
+
+def test_service_names_since_until_filter():
+    client.post("/metrics", json={
+        "service": "old", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "new", "status": "healthy", "response_time_ms": 1.0, "timestamp": 200.0,
+    })
+    resp = client.get("/metrics/services/names?since=150")
+    assert resp.status_code == 200
+    assert resp.json()["names"] == ["new"]
+
+
+def test_service_names_since_greater_than_until_rejected():
+    resp = client.get("/metrics/services/names?since=200&until=100")
+    assert resp.status_code == 400
+    assert "since must be less than or equal to until" in resp.json()["detail"]
+
+
+def test_service_names_does_not_collide_with_detail_route():
+    # ルート定義順により、`/metrics/services/names` が
+    # `/metrics/services/{service_name}` より優先されて固定 path として
+    # 解釈されること。`names` という名前のサービスを投入した状態で確認。
+    client.post("/metrics", json={
+        "service": "names", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/names")
+    assert resp.status_code == 200
+    data = resp.json()
+    # 集約 detail オブジェクト（service / total_checks 等）ではなく軽量レスポンスが返ること。
+    assert "names" in data and isinstance(data["names"], list)
+    assert "uptime_pct" not in data
+    assert data["names"] == ["names"]
+
+
+def test_service_names_limit_capped():
+    resp = client.get("/metrics/services/names?limit=99999")
+    # METRICS_MAX_LIMIT (既定 1000) を超える指定は 422 で拒否される
+    assert resp.status_code == 422

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import axios, { AxiosError } from "axios";
-import { app } from "./app";
+import { app, ANALYTICS_URL } from "./app";
 
 describe("API Gateway", () => {
   describe("GET /health", () => {
@@ -252,6 +252,125 @@ describe("API Gateway", () => {
       const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
       const res = await request(app).get("/api/metrics/services?sort=bogus");
       expect(res.status).toBe(422);
+      spy.mockRestore();
+    });
+  });
+
+  describe("GET /api/metrics/services/names", () => {
+    it("forwards to /metrics/services/names without query string when no params", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { count: 0, total: 0, limit: 100, offset: 0, order: "asc", names: [] },
+        } as never);
+      const res = await request(app).get("/api/metrics/services/names");
+      expect(res.status).toBe(200);
+      expect(res.body.names).toEqual([]);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      // クエリ無しなので URL に "?" は付かないこと（buildUpstreamParams の挙動回帰）
+      expect(calledUrl).toBe(`${ANALYTICS_URL}/metrics/services/names`);
+      spy.mockRestore();
+    });
+
+    it("forwards since/until/q/order/limit/offset query params", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { count: 1, total: 1, limit: 50, offset: 0, order: "desc", names: ["web"] },
+        } as never);
+      const res = await request(app).get(
+        "/api/metrics/services/names?since=100&until=200&q=we&order=desc&limit=50&offset=0"
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.names).toEqual(["web"]);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("since=100");
+      expect(calledUrl).toContain("until=200");
+      expect(calledUrl).toContain("q=we");
+      expect(calledUrl).toContain("order=desc");
+      expect(calledUrl).toContain("limit=50");
+      expect(calledUrl).toContain("offset=0");
+      spy.mockRestore();
+    });
+
+    it("drops empty-string query params before forwarding", async () => {
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { count: 0, total: 0, limit: 100, offset: 0, order: "asc", names: [] },
+        } as never);
+      const res = await request(app).get(
+        "/api/metrics/services/names?since=&q=&order="
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("since=");
+      expect(calledUrl).not.toContain("q=");
+      expect(calledUrl).not.toContain("order=");
+      spy.mockRestore();
+    });
+
+    it("does NOT forward unrelated query params (e.g. status / sort / service)", async () => {
+      // /metrics/services/names は status / sort / service を受け付けないため、
+      // クライアントが付与しても上流には渡さないこと。
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { count: 0, total: 0, limit: 100, offset: 0, order: "asc", names: [] },
+        } as never);
+      const res = await request(app).get(
+        "/api/metrics/services/names?status=healthy&sort=last_seen&service=web"
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("status=");
+      expect(calledUrl).not.toContain("sort=");
+      expect(calledUrl).not.toContain("service=");
+      spy.mockRestore();
+    });
+
+    it("propagates 400 from analytics on invalid query", async () => {
+      const err = new AxiosError("Bad Request");
+      err.response = {
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never,
+        data: { detail: "q must not be blank" },
+      };
+      const spy = jest.spyOn(axios, "get").mockRejectedValueOnce(err);
+      const res = await request(app).get("/api/metrics/services/names?q=foo");
+      expect(res.status).toBe(400);
+      expect(res.body.detail).toContain("q must not be blank");
+      spy.mockRestore();
+    });
+
+    it("returns 502 when analytics is down", async () => {
+      const res = await request(app).get("/api/metrics/services/names");
+      expect(res.status).toBe(502);
+      expect(res.body.error).toBe("Analytics service unavailable");
+    });
+
+    it("is preferred over /api/metrics/services/:name for the exact literal 'names'", async () => {
+      // ルート登録順により、`/api/metrics/services/names` リクエストは names エンドポイントに
+      // ヒットし、`{name:"names"}` の単一サービス詳細ルートには落ちないこと。
+      const spy = jest
+        .spyOn(axios, "get")
+        .mockResolvedValueOnce({
+          status: 200,
+          data: { count: 0, total: 0, limit: 100, offset: 0, order: "asc", names: [] },
+        } as never);
+      await request(app).get("/api/metrics/services/names");
+      const calledUrl = spy.mock.calls[0][0] as string;
+      // 単一サービスルートに行くと "/metrics/services/names?..." ではなく
+      // 同じ path だが「service-detail」label でログされる差しか無いため、
+      // ここでは forward 先 URL の末尾が "/names" であって URL エンコードされた
+      // パスではないことを確認する。
+      expect(calledUrl).toBe(`${ANALYTICS_URL}/metrics/services/names`);
       spy.mockRestore();
     });
   });

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -173,6 +173,20 @@ app.get("/api/metrics/timeseries", (req: Request, res: Response) =>
   ),
 );
 
+// distinct な service 名一覧のみを返す軽量エンドポイントを analytics-api にプロキシする。
+// `:name` パラメタ付きルート (`/api/metrics/services/:name`) より前に登録する必要がある
+// — Express は登録順にマッチするため、後ろに置くと `name = "names"` の単一サービス
+// 詳細リクエストとして解釈されてしまう。
+app.get("/api/metrics/services/names", (req: Request, res: Response) =>
+  proxyAnalyticsGet(
+    req,
+    res,
+    "/metrics/services/names",
+    ["since", "until", "q", "order", "limit", "offset"],
+    "service-names",
+  ),
+);
+
 // 単一サービスの詳細を返すエンドポイント。analytics-api 側で 404 が返るため、
 // proxy 経由でもそのまま 404 を伝播する。
 app.get(


### PR DESCRIPTION
## 概要

フィルタ後のレコードに含まれる distinct な service 名のみを返す軽量エンドポイント `GET /metrics/services/names` を analytics-api に追加し、api-gateway 側でもプロキシ可能にする。

- distinct な service 名のみを返却し、`/metrics/services` のような per-service の uptime / first_seen / last_seen / latest_status / percentile 集計は行わない
- フィルタドロップダウンの populate のように「名前だけ欲しい」用途で、`/metrics/services` よりも小さなペイロード・低コストで応答できる
- `since` / `until` / `q` フィルタ・`order` (asc/desc)・`limit` / `offset` ページングをサポート
- api-gateway は既存の `proxyAnalyticsGet` ヘルパで `/api/metrics/services/names` を提供

## 変更点

- `analytics-api/main.py`
  - `MetricsStore.distinct_services(since, until, q)` を追加（`filter()` 結果から重複排除）
  - `GET /metrics/services/names` エンドポイントを追加。`/metrics/services/{service_name}` より前に登録し、リテラル `names` パスが優先される
  - 既存と同じ since/until/q 検証ヘルパを再利用
- `analytics-api/test_main.py`
  - 空 store / distinct & sort / order=desc / pagination / q (大文字小文字無視) / q 空白拒否 / since-until / since>until 拒否 / detail route との優先度 / limit 上限 422、計 10 ケース追加
- `api-gateway/src/app.ts`
  - `/api/metrics/services/names` プロキシを追加。`/api/metrics/services/:name` より前に登録
  - allowedParams は `since` / `until` / `q` / `order` / `limit` / `offset`
- `api-gateway/src/app.test.ts`
  - クエリ無し転送 / 全クエリ転送 / 空文字除外 / 関係ないクエリの非転送 / 上流 400 伝播 / 502 / `:name` ルートより優先、計 7 ケース追加
- `README.md`
  - api-gateway / analytics-api それぞれのエンドポイント表に追記し、レスポンス例セクションを追加

## ローカル確認

- `analytics-api`: `flake8 --max-line-length=120 main.py` OK、`pytest -v` → **170 passed**（既存 160 + 新規 10）
- `api-gateway`: `npm run lint` OK、`npm test` → **61 passed**（既存 54 + 新規 7）

## 動作確認手順

```bash
docker compose up -d
curl -X POST http://localhost:3000/api/metrics \
  -H 'Content-Type: application/json' \
  -d '{"service":"api-gateway","status":"healthy","response_time_ms":12.3}'
curl -X POST http://localhost:3000/api/metrics \
  -H 'Content-Type: application/json' \
  -d '{"service":"billing","status":"healthy","response_time_ms":40.0}'
curl http://localhost:3000/api/metrics/services/names
# => {"count":2,"total":2,"limit":100,"offset":0,"order":"asc","names":["api-gateway","billing"]}
curl 'http://localhost:3000/api/metrics/services/names?q=API'
# => {"count":1,"total":1,..., "names":["api-gateway"]}
```

Closes #77