### PR TITLE
feat: DELETE /metrics に status フィルタを追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -167,14 +167,20 @@ class MetricsStore:
         records_snapshot = self.filter(since=since, until=until, q=q)
         return list({r.service for r in records_snapshot})
 
-    def delete(self, service: str | None = None, before: float | None = None) -> int:
+    def delete(
+        self,
+        service: str | None = None,
+        before: float | None = None,
+        status: str | None = None,
+    ) -> int:
         """Delete records matching the given filters.
 
         Records are removed only when they match every provided filter:
         - service: only records whose service equals this value
         - before:  only records whose timestamp is strictly less than this value
+        - status:  only records whose status equals this value
         """
-        if service is None and before is None:
+        if service is None and before is None and status is None:
             return 0
         with self._lock:
             initial = len(self.records)
@@ -186,13 +192,16 @@ class MetricsStore:
                 if before is not None and r.timestamp >= before:
                     kept.append(r)
                     continue
-                # falls through both filters → delete
+                if status is not None and r.status != status:
+                    kept.append(r)
+                    continue
+                # falls through all filters → delete
             self.records = kept
             deleted = initial - len(self.records)
         if deleted > 0:
             logger.info(
-                "Deleted %d records (service=%s, before=%s)",
-                deleted, service, before,
+                "Deleted %d records (service=%s, before=%s, status=%s)",
+                deleted, service, before, status,
             )
         return deleted
 
@@ -592,7 +601,14 @@ def delete_metrics(
         gt=0,
         description=(
             "この Unix timestamp より前（<）のレコードを削除。"
-            "service と組み合わせると AND 条件になる"
+            "service / status と組み合わせると AND 条件になる"
+        ),
+    ),
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=(
+            f"削除対象のステータス（{', '.join(ALLOWED_STATUSES)}）。"
+            "service / before と組み合わせると AND 条件になる"
         ),
     ),
 ):
@@ -601,12 +617,12 @@ def delete_metrics(
     normalized = service.strip() if service is not None else None
     if normalized is not None and not normalized:
         return {"error": "service must not be blank", "deleted_count": 0}
-    if normalized is None and before is None:
+    if normalized is None and before is None and status is None:
         raise HTTPException(
             status_code=400,
-            detail="At least one of 'service' or 'before' must be provided",
+            detail="At least one of 'service', 'before' or 'status' must be provided",
         )
-    deleted = store.delete(service=normalized, before=before)
+    deleted = store.delete(service=normalized, before=before, status=status)
     if deleted == 0:
         message = "No metrics matched the given filters"
         return {
@@ -614,11 +630,13 @@ def delete_metrics(
             "deleted_count": 0,
             "service": normalized,
             "before": before,
+            "status": status,
         }
     return {
         "message": "Metrics deleted",
         "service": normalized,
         "before": before,
+        "status": status,
         "deleted_count": deleted,
     }
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -387,11 +387,78 @@ def test_delete_metrics_not_found():
 
 
 def test_delete_metrics_missing_param():
-    # service と before のどちらも未指定の場合は 400 で拒否される
+    # service / before / status のいずれも未指定の場合は 400 で拒否される
     resp = client.delete("/metrics")
     assert resp.status_code == 400
-    assert "service" in resp.json()["detail"]
-    assert "before" in resp.json()["detail"]
+    detail = resp.json()["detail"]
+    assert "service" in detail
+    assert "before" in detail
+    assert "status" in detail
+
+
+def test_delete_metrics_by_status_only():
+    # status のみ指定で unhealthy のレコードだけが削除されること
+    client.post("/metrics", json={"service": "web", "status": "healthy", "response_time_ms": 1})
+    client.post("/metrics", json={"service": "db", "status": "unhealthy", "response_time_ms": 2})
+    client.post("/metrics", json={"service": "cache", "status": "unhealthy", "response_time_ms": 3})
+
+    resp = client.delete("/metrics?status=unhealthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_count"] == 2
+    assert data["status"] == "unhealthy"
+    assert data["service"] is None
+    assert data["before"] is None
+
+    remaining = client.get("/metrics").json()
+    assert remaining["total"] == 1
+    assert remaining["metrics"][0]["service"] == "web"
+
+
+def test_delete_metrics_by_status_and_before_combined():
+    # status と before の AND で「古い unhealthy」だけ削除されること
+    base = time.time()
+    client.post("/metrics", json={
+        "service": "a", "status": "unhealthy",
+        "response_time_ms": 1, "timestamp": base - 1000,
+    })
+    client.post("/metrics", json={
+        "service": "b", "status": "unhealthy",
+        "response_time_ms": 2, "timestamp": base,
+    })
+    client.post("/metrics", json={
+        "service": "c", "status": "healthy",
+        "response_time_ms": 3, "timestamp": base - 1000,
+    })
+
+    cutoff = base - 500
+    resp = client.delete(f"/metrics?status=unhealthy&before={cutoff}")
+    assert resp.status_code == 200
+    data = resp.json()
+    # a だけ（古い かつ unhealthy）が削除される
+    assert data["deleted_count"] == 1
+    assert data["status"] == "unhealthy"
+    assert data["before"] == cutoff
+
+    remaining = client.get("/metrics").json()
+    remaining_services = sorted(m["service"] for m in remaining["metrics"])
+    assert remaining_services == ["b", "c"]
+
+
+def test_delete_metrics_rejects_invalid_status():
+    # status は Literal で 422
+    resp = client.delete("/metrics?status=broken")
+    assert resp.status_code == 422
+
+
+def test_delete_metrics_by_status_no_match_returns_zero():
+    client.post("/metrics", json={"service": "a", "status": "healthy", "response_time_ms": 1})
+    resp = client.delete("/metrics?status=degraded")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deleted_count"] == 0
+    assert "error" in data
+    assert data["status"] == "degraded"
 
 
 def test_delete_metrics_by_before_only():
@@ -539,6 +606,29 @@ def test_metrics_store_delete_unit():
     assert s.delete(before=100) == 1
     remaining = [r.timestamp for r in s.get_all()]
     assert remaining == [100]
+
+    # status のみ
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="b", status="unhealthy", response_time_ms=20, timestamp=100))
+    s.add(MetricRecord(service="c", status="unhealthy", response_time_ms=30, timestamp=200))
+    assert s.delete(status="unhealthy") == 2
+    assert [r.service for r in s.get_all()] == ["a"]
+
+    # service + before + status の三段 AND
+    s = MetricsStore()
+    s.add(MetricRecord(service="a", status="unhealthy", response_time_ms=10, timestamp=100))
+    s.add(MetricRecord(service="a", status="healthy", response_time_ms=20, timestamp=100))
+    s.add(MetricRecord(service="a", status="unhealthy", response_time_ms=30, timestamp=300))
+    s.add(MetricRecord(service="b", status="unhealthy", response_time_ms=40, timestamp=100))
+    # 「a の 古い (before=200) unhealthy」のみ 1 件削除
+    assert s.delete(service="a", before=200, status="unhealthy") == 1
+    remaining = sorted((r.service, r.status, r.timestamp) for r in s.get_all())
+    assert remaining == [
+        ("a", "healthy", 100),
+        ("a", "unhealthy", 300),
+        ("b", "unhealthy", 100),
+    ]
 
 
 def test_metrics_store_delete_nonexistent():

--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -658,6 +658,53 @@ describe("API Gateway", () => {
       expect([200, 204]).toContain(res.status);
       spy.mockRestore();
     });
+
+    it("forwards status filter to analytics", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: { message: "Metrics deleted", status: "unhealthy", deleted_count: 4 },
+      } as never);
+      const res = await request(app).delete("/api/metrics?status=unhealthy");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("status=unhealthy");
+      spy.mockRestore();
+    });
+
+    it("forwards status combined with service and before", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: {
+          message: "Metrics deleted",
+          service: "web",
+          before: 1700000000,
+          status: "unhealthy",
+          deleted_count: 1,
+        },
+      } as never);
+      const res = await request(app).delete(
+        "/api/metrics?service=web&before=1700000000&status=unhealthy",
+      );
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).toContain("before=1700000000");
+      expect(calledUrl).toContain("status=unhealthy");
+      spy.mockRestore();
+    });
+
+    it("does not forward empty status param", async () => {
+      const spy = jest.spyOn(axios, "delete").mockResolvedValueOnce({
+        status: 200,
+        data: { message: "Metrics deleted", deleted_count: 1 },
+      } as never);
+      const res = await request(app).delete("/api/metrics?service=web&status=");
+      expect(res.status).toBe(200);
+      const calledUrl = spy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("service=web");
+      expect(calledUrl).not.toContain("status=");
+      spy.mockRestore();
+    });
   });
 
   describe("GET /api/check", () => {

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -251,7 +251,7 @@ app.delete("/api/metrics", (req: Request, res: Response) =>
     req,
     res,
     "/metrics",
-    ["service", "before"],
+    ["service", "before", "status"],
     "delete-metrics",
   ),
 );


### PR DESCRIPTION
## 概要

- `MetricsStore.delete()` を `status` 引数で拡張し、`(service, before, status)` の三段 AND 評価をサポート。
- `DELETE /metrics` のシグネチャに `status: StatusLiteral` を追加。`Literal` で 422 バリデーション。
- 「少なくとも 1 フィルタ必須」ガードに `status` を含めるよう更新。
- `api-gateway` 側 `/api/metrics` DELETE プロキシの `allowedParams` に `status` を追加。空文字は既存ロジックで除外される。
- 既存の `delete_metrics` レスポンスに `"status"` フィールドを追加（マッチなしレスポンスも含む）。

## 動作確認

ローカルで CI 相当を全パス：

- `analytics-api`: `flake8 --max-line-length=120 main.py` & `pytest -q` → 174 passed
- `api-gateway`: `npm run lint` & `npm test` → 64 passed
- `health-checker`: `go vet ./... && go test ./...` → OK

## 動作例

```
# 古い unhealthy だけ削除
curl -X DELETE 'http://localhost:8000/api/metrics?status=unhealthy&before=1700000000'
# {"message":"Metrics deleted","service":null,"before":1.7e9,"status":"unhealthy","deleted_count":12}
```

Closes #79