### PR TITLE
feat(analytics-api): /metrics/services の sort に latest_response_ms を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -35,6 +35,7 @@ ServiceSortFieldLiteral = Literal[
     "last_seen",
     "first_seen",
     "latest_status",
+    "latest_response_ms",
 ]
 
 
@@ -855,7 +856,7 @@ def list_services(
         default="service",
         description=(
             "ソートフィールド（service / total_checks / healthy_checks / uptime_pct / "
-            "last_seen / first_seen / latest_status）"
+            "last_seen / first_seen / latest_status / latest_response_ms）"
         ),
     ),
     order: SortOrderLiteral = Query(

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1562,6 +1562,72 @@ def test_list_services_latest_response_ms_is_rounded():
     assert services[0]["latest_response_ms"] == 12.35
 
 
+def test_list_services_sort_by_latest_response_ms_asc():
+    # latest_response_ms を昇順にソートできること（最も速いサービスが先頭）。
+    client.post("/metrics", json={
+        "service": "slow", "status": "healthy",
+        "response_time_ms": 500.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "fast", "status": "healthy",
+        "response_time_ms": 10.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "mid", "status": "healthy",
+        "response_time_ms": 100.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?sort=latest_response_ms&order=asc")
+    assert resp.status_code == 200
+    services = resp.json()["services"]
+    assert [s["service"] for s in services] == ["fast", "mid", "slow"]
+
+
+def test_list_services_sort_by_latest_response_ms_desc():
+    # latest_response_ms を降順にソートできること（最も遅いサービスが先頭）。
+    client.post("/metrics", json={
+        "service": "slow", "status": "healthy",
+        "response_time_ms": 500.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "fast", "status": "healthy",
+        "response_time_ms": 10.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "mid", "status": "healthy",
+        "response_time_ms": 100.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services?sort=latest_response_ms&order=desc")
+    assert resp.status_code == 200
+    services = resp.json()["services"]
+    assert [s["service"] for s in services] == ["slow", "mid", "fast"]
+
+
+def test_list_services_sort_by_latest_response_ms_uses_latest_observation():
+    # 同一サービスに複数観測がある場合、最新タイムスタンプの observation の
+    # response_time_ms が並び替えに使われること（latest_response_ms と整合）。
+    # web: 最終観測 = 200ms / db: 最終観測 = 50ms
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy",
+        "response_time_ms": 5.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy",
+        "response_time_ms": 200.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy",
+        "response_time_ms": 999.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "healthy",
+        "response_time_ms": 50.0, "timestamp": 300.0,
+    })
+    resp = client.get("/metrics/services?sort=latest_response_ms&order=asc")
+    assert resp.status_code == 200
+    services = resp.json()["services"]
+    assert [s["service"] for s in services] == ["db", "web"]
+
+
 def test_get_service_detail_404_when_no_data():
     resp = client.get("/metrics/services/unknown")
     assert resp.status_code == 404


### PR DESCRIPTION
## 変更概要

- `ServiceSortFieldLiteral` に `latest_response_ms` を追加し、`/metrics/services?sort=latest_response_ms` での並び替えを可能にする
- 最新観測の応答時間でサービスをランキングできるため、ダッシュボードの「最も遅いサービス Top N」表示などが 1 リクエストで実現できる
- 既存の `sort` デフォルト (`service`) や他のソートフィールドの挙動は変更なし（追加のみ）
- 並び替えロジックは既存の `services.sort(key=lambda s: s[sort], ...)` を再利用しており、`latest_response_ms` はレスポンス組み立て時に既に dict に含まれているため追加実装は不要

## 追加テスト

- `test_list_services_sort_by_latest_response_ms_asc`: 昇順で最速サービスが先頭になる
- `test_list_services_sort_by_latest_response_ms_desc`: 降順で最遅サービスが先頭になる
- `test_list_services_sort_by_latest_response_ms_uses_latest_observation`: 同一サービスに複数観測がある場合、最新タイムスタンプの observation が並び替えに使われる（`latest_response_ms` 計算と整合）

## 対応 Issue

Closes #81

## 動作確認手順

```sh
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
```

ローカルで実行済み: `177 passed in 2.08s` / flake8 警告なし