### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/timeseries を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Response:
 | GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
 | GET | `/metrics/services/names` | distinct な service 名のみを返す軽量エンドポイント（per-service 集計を行わずペイロード最小化、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
 | GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
+| GET | `/metrics/services/{service_name}/timeseries` | 単一サービスに絞った時系列バケット集計（`?bucket_seconds=` / `?status=` / `?since=` / `?until=`）。該当サービスが存在しなければ 404 |
 
 #### Delete Metrics
 
@@ -348,6 +349,20 @@ curl "http://localhost:8001/metrics/timeseries?bucket_seconds=300&service=web&st
 ```
 
 `by_status` は `ALLOWED_STATUSES` の全キーを 0 初期化したマップで返るため、クライアントは存在チェックなしで参照できる。
+
+#### Service Timeseries
+
+`/metrics/services/{service_name}/timeseries` は単一サービスに絞った時系列バケットを返す。`/metrics/timeseries?service=X` と同じ buckets 形（`bucket_start` / `total` / `by_status` / `avg_response_ms` / `min_response_ms` / `max_response_ms` / `p50_response_ms` / `p95_response_ms` / `p99_response_ms`）に `service` フィールドを付与して返す。サービス起点で URL を組み立てられるため、ダッシュボードのサービス詳細画面から 1 リクエストで時系列データを取り回せる。
+
+該当サービスのレコードが (`since` / `until` 範囲内に) 1 件も無い場合は `404 No metrics found for service '...'` を返す（`/metrics/services/{service_name}` 詳細エンドポイントと同じセマンティクス）。一方、`status` フィルタはあくまでバケット内の集計を絞り込むだけで、存在判定には影響しない（サービス自体は存在するが指定 status のレコードが 0 件なら、空 `buckets` の 200 が返る）。
+
+```bash
+# 既定 (60秒バケット)
+curl http://localhost:8001/metrics/services/web/timeseries
+
+# 5分バケット + status 絞り込み + 時間範囲
+curl "http://localhost:8001/metrics/services/web/timeseries?bucket_seconds=300&status=healthy&since=1700000000&until=1700003600"
+```
 
 ### Health Checker (port 8002)
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -298,6 +298,31 @@ class MetricsStore:
             "p99_response_ms": round(_percentile(sorted_times, 99), 2),
         }
 
+    def has_records_for_service(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> bool:
+        """指定サービスのレコードが、フィルタ範囲内に 1 件以上存在するかを返す。
+
+        `/metrics/services/{service_name}/timeseries` のような「データ無しは 404」
+        セマンティクスを実現するため、buckets を組み立てる前に存在チェックを行う。
+        全件走査だが、フィルタ後の長さを評価する `filter()` と違って match を 1 件
+        見つけ次第 break するため、データ量が多い場合に短絡できる。
+        """
+        with self._lock:
+            snapshot = list(self.records)
+        for r in snapshot:
+            if r.service != service:
+                continue
+            if since is not None and r.timestamp < since:
+                continue
+            if until is not None and r.timestamp > until:
+                continue
+            return True
+        return False
+
     def timeseries(
         self,
         bucket_seconds: int,
@@ -1071,6 +1096,84 @@ def get_service_detail(
             detail=f"No metrics found for service '{normalized}'",
         )
     return detail
+
+
+@app.get("/metrics/services/{service_name}/timeseries")
+def get_service_timeseries(
+    service_name: str,
+    bucket_seconds: int = Query(
+        default=60,
+        ge=1,
+        le=86400,
+        description="バケット幅（秒）。1秒〜1日（86400秒）の範囲で指定。",
+    ),
+    status: StatusLiteral | None = Query(
+        default=None,
+        description=f"ステータスで絞り込み（{', '.join(ALLOWED_STATUSES)}）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）のレコードに絞り込む",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）のレコードに絞り込む",
+    ),
+):
+    """単一サービスを対象とした時系列バケット集計を返す。
+
+    `/metrics/timeseries?service=X` と同じ buckets 形を返すが、
+
+    - service 名をパスから受け取ることで URL が宣言的になり、UI 側でのクエリ生成が不要
+    - 該当サービスのレコードが (since/until 範囲内に) 1 件も無い場合は 404 を返す
+      （`/metrics/services/{service_name}` 詳細エンドポイントと同じ「存在しない service は
+      404」セマンティクスを共有）
+
+    という点が異なる。response には `service` フィールドを付与して、UI 側で
+    どのサービスの結果かを混同しないようにする。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    # status フィルタは buckets の中身を空に絞り込むだけで、サービス自体は存在しうるため、
+    # 存在チェックは since/until だけで判定する（status フィルタ後の空 buckets は通常応答）。
+    if not store.has_records_for_service(service=normalized, since=since, until=until):
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+
+    buckets = store.timeseries(
+        bucket_seconds=bucket_seconds,
+        service=normalized,
+        status=status,
+        since=since,
+        until=until,
+    )
+    return {
+        "service": normalized,
+        "bucket_seconds": bucket_seconds,
+        "count": len(buckets),
+        "buckets": buckets,
+    }
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2113,3 +2113,170 @@ def test_service_names_limit_capped():
     resp = client.get("/metrics/services/names?limit=99999")
     # METRICS_MAX_LIMIT (既定 1000) を超える指定は 422 で拒否される
     assert resp.status_code == 422
+
+
+# === /metrics/services/{service_name}/timeseries ===
+
+def test_service_timeseries_404_when_service_has_no_data():
+    # 該当サービスのレコードが 1 件も無ければ 404 を返す。
+    # /metrics/services/{name} の詳細エンドポイントと一貫したセマンティクス。
+    client.post("/metrics", json={
+        "service": "other", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries")
+    assert resp.status_code == 404
+    assert "web" in resp.json()["detail"]
+
+
+def test_service_timeseries_returns_buckets_for_service():
+    # 同一サービスの 2 観測（同一バケット [60,120) 内）がまとまり、別サービスは含まれない。
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 10.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 20.0, "timestamp": 110.0,
+    })
+    client.post("/metrics", json={
+        "service": "api", "status": "healthy", "response_time_ms": 5.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?bucket_seconds=60")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["bucket_seconds"] == 60
+    assert data["count"] == 1
+    bucket = data["buckets"][0]
+    assert bucket["bucket_start"] == 60.0
+    assert bucket["total"] == 2
+    assert bucket["by_status"]["healthy"] == 1
+    assert bucket["by_status"]["unhealthy"] == 1
+    # api の値（5.0）は混入しないこと
+    assert bucket["min_response_ms"] == 10.0
+    assert bucket["max_response_ms"] == 20.0
+
+
+def test_service_timeseries_strips_whitespace_in_path():
+    # path の service_name は trim される（/metrics/services/{name} と同じ規約）。
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/%20web%20/timeseries")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "web"
+
+
+def test_service_timeseries_rejects_blank_path():
+    # 空白のみの service_name は 400。
+    resp = client.get("/metrics/services/%20%20/timeseries")
+    assert resp.status_code == 400
+
+
+def test_service_timeseries_rejects_overlong_path():
+    overlong = "x" * 200
+    resp = client.get(f"/metrics/services/{overlong}/timeseries")
+    assert resp.status_code == 400
+
+
+def test_service_timeseries_filters_by_status():
+    # status フィルタは buckets の中身を絞り込むだけで、サービス存在判定には影響しない。
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 60.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 2.0, "timestamp": 60.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?bucket_seconds=60&status=unhealthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    bucket = data["buckets"][0]
+    assert bucket["total"] == 1
+    assert bucket["by_status"]["unhealthy"] == 1
+    assert bucket["by_status"]["healthy"] == 0
+
+
+def test_service_timeseries_filters_by_since_until():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 2.0, "timestamp": 200.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 3.0, "timestamp": 300.0,
+    })
+    resp = client.get(
+        "/metrics/services/web/timeseries?bucket_seconds=60&since=150&until=250",
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["buckets"][0]["total"] == 1
+
+
+def test_service_timeseries_404_when_filter_excludes_all():
+    # サービス自体は存在するが、since/until 範囲外で 0 件になる場合も 404 を返す。
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 100.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?since=500&until=600")
+    assert resp.status_code == 404
+
+
+def test_service_timeseries_rejects_invalid_bucket():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?bucket_seconds=0")
+    assert resp.status_code == 422
+
+
+def test_service_timeseries_rejects_invalid_status():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?status=bogus")
+    assert resp.status_code == 422
+
+
+def test_service_timeseries_rejects_since_greater_than_until():
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 1.0, "timestamp": 1.0,
+    })
+    resp = client.get("/metrics/services/web/timeseries?since=200&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_timeseries_matches_global_timeseries_with_service_filter():
+    # /metrics/timeseries?service=web と /metrics/services/web/timeseries の
+    # buckets が一致することを確認（実装の冗長性を排除し UI 側の選択を任せる）。
+    for ts, status, rt in [
+        (60.0, "healthy", 10.0),
+        (60.0, "healthy", 20.0),
+        (180.0, "unhealthy", 30.0),
+    ]:
+        client.post("/metrics", json={
+            "service": "web", "status": status, "response_time_ms": rt, "timestamp": ts,
+        })
+    client.post("/metrics", json={
+        "service": "api", "status": "healthy", "response_time_ms": 99.0, "timestamp": 60.0,
+    })
+    global_resp = client.get("/metrics/timeseries?bucket_seconds=60&service=web")
+    service_resp = client.get("/metrics/services/web/timeseries?bucket_seconds=60")
+    assert global_resp.status_code == 200
+    assert service_resp.status_code == 200
+    assert global_resp.json()["buckets"] == service_resp.json()["buckets"]
+
+
+def test_metrics_store_has_records_for_service_unit():
+    s = MetricsStore()
+    assert s.has_records_for_service("web") is False
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=1.0, timestamp=100.0))
+    s.add(MetricRecord(service="api", status="healthy", response_time_ms=2.0, timestamp=200.0))
+    assert s.has_records_for_service("web") is True
+    assert s.has_records_for_service("api") is True
+    assert s.has_records_for_service("unknown") is False
+    # since / until で短絡する
+    assert s.has_records_for_service("web", since=50, until=150) is True
+    assert s.has_records_for_service("web", since=500) is False
+    assert s.has_records_for_service("web", until=50) is False


### PR DESCRIPTION
## 概要

- 単一サービスを対象とした時系列バケット集計エンドポイント `/metrics/services/{service_name}/timeseries` を追加
- `/metrics/timeseries?service=X` と同じ buckets 形（`bucket_start` / `total` / `by_status` / `avg/min/max/p50/p95/p99_response_ms`）に `service` フィールドを付与して返す
- サービスが指定範囲内に 1 件も無ければ `404`（`/metrics/services/{service_name}` 詳細エンドポイントと一貫）
- 内部に `MetricsStore.has_records_for_service` を新設（match 1 件で短絡できる）
- 既存と同じバリデーション（`bucket_seconds` 1〜86400、`since<=until`、有限値、空白 trim、長さ上限）
- README の Analytics API テーブル・節を更新
- テスト 11 ケース追加（成功・404 ２パターン・status / since-until フィルタ・各種 4xx・global /metrics/timeseries との一致・store ユニット）

## 対応 Issue

Closes #85

## 動作確認手順

```bash
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
```

ローカルで全 194 テスト pass を確認済み。