### PR TITLE
feat(analytics-api): /metrics/count に登場サービス数 services を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Response:
 | GET | `/metrics/overview` | 全レコードを 1 つに集約したトップレベル稼働サマリ（`?service=` / `?status=` / `?since=` / `?until=`） |
 | GET | `/metrics/services` | サービス一覧（観測数・healthy 数・uptime%・最新ステータス・初回／最終観測時刻） |
 | GET | `/metrics/services/names` | distinct な service 名のみを返す軽量エンドポイント（per-service 集計を行わずペイロード最小化、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
+| GET | `/metrics/count` | フィルタ後のレコード件数・status 別件数・登場サービス数のみを返す軽量エンドポイント（`?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/metrics/services/{service_name}/timeseries` | 単一サービスに絞った時系列バケット集計（`?bucket_seconds=` / `?status=` / `?since=` / `?until=`）。該当サービスが存在しなければ 404 |
 
@@ -310,6 +311,36 @@ curl "http://localhost:8001/metrics/services/names?since=$(($(date +%s) - 3600))
   "names": ["api-gateway", "billing", "user-service"]
 }
 ```
+
+#### Count Only
+
+`/metrics/count` はフィルタに合致するレコード本体を返さず、件数・status 別件数・登場サービス数だけを返す軽量エンドポイント。`/metrics?limit=1` 相当のメタデータだけが必要な UI（バッジ表示・ページャ初期化・「X サービス × Y チェック」サマリーなど）向けで、レコードの JSON 直列化コストを避けられる。
+
+```bash
+# 全件カウント
+curl http://localhost:8001/metrics/count
+
+# サービス絞り込み
+curl "http://localhost:8001/metrics/count?service=web"
+
+# status + 時間範囲
+curl "http://localhost:8001/metrics/count?status=unhealthy&since=1700000000"
+
+# 部分一致検索（大文字小文字無視）
+curl "http://localhost:8001/metrics/count?q=api"
+```
+
+レスポンス例:
+
+```json
+{
+  "total": 6,
+  "services": 3,
+  "by_status": {"healthy": 3, "unhealthy": 1, "degraded": 1, "unknown": 1}
+}
+```
+
+`by_status` は `ALLOWED_STATUSES` の全キーを 0 で初期化したマップで返るため、クライアントは存在チェックなしで参照できる。`services` はフィルタ通過後のレコードに登場した service 名のユニーク数（status / since / until / q によるフィルタは反映済み）。
 
 #### Get Timeseries
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -781,6 +781,8 @@ def get_metrics_count(
     向け。レコード本体を返さないため、転送量と JSON 直列化コストを抑えられる。
     `by_status` は `ALLOWED_STATUSES` の全キーを 0 で初期化して返すため、
     クライアントは存在チェックなしで各ステータスにアクセスできる。
+    `services` は該当レコードに登場した service 名のユニーク数で、
+    ダッシュボードの「X サービス × Y チェック」サマリーで利用する。
     """
     if since is not None and until is not None and since > until:
         raise HTTPException(
@@ -799,9 +801,15 @@ def get_metrics_count(
         service=service, status=status, since=since, until=until, q=q_value,
     )
     by_status: dict[str, int] = {s: 0 for s in ALLOWED_STATUSES}
+    distinct_services: set[str] = set()
     for r in records:
         by_status[r.status] = by_status.get(r.status, 0) + 1
-    return {"total": len(records), "by_status": by_status}
+        distinct_services.add(r.service)
+    return {
+        "total": len(records),
+        "services": len(distinct_services),
+        "by_status": by_status,
+    }
 
 
 @app.get("/metrics/timeseries")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1453,6 +1453,8 @@ def test_count_empty_store():
     assert data["by_status"] == {
         "healthy": 0, "unhealthy": 0, "degraded": 0, "unknown": 0,
     }
+    # 空ストアでは登場した service 数は 0
+    assert data["services"] == 0
 
 
 def test_count_all_records():
@@ -1464,6 +1466,8 @@ def test_count_all_records():
     assert data["by_status"] == {
         "healthy": 3, "unhealthy": 1, "degraded": 1, "unknown": 1,
     }
+    # api / db / worker の 3 サービスがレコードに登場している
+    assert data["services"] == 3
 
 
 def test_count_filtered_by_service():
@@ -1476,6 +1480,8 @@ def test_count_filtered_by_service():
     assert data["by_status"]["unhealthy"] == 1
     assert data["by_status"]["degraded"] == 0
     assert data["by_status"]["unknown"] == 0
+    # service フィルタで該当サービス 1 つに絞られる
+    assert data["services"] == 1
 
 
 def test_count_filtered_by_status():
@@ -1524,6 +1530,44 @@ def test_count_invalid_status_returns_422():
     # FastAPI の Query Literal 検査により未知 status は 422 になる
     resp = client.get("/metrics/count?status=bogus")
     assert resp.status_code == 422
+
+
+def test_count_services_distinct_with_status_filter():
+    # status フィルタ後に残ったレコードの service ユニーク数を返すこと。
+    # healthy: api×2 + db×1 = 3件 / 2サービス（api, db）になる。
+    _seed_for_count()
+    resp = client.get("/metrics/count?status=healthy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["services"] == 2
+
+
+def test_count_services_distinct_with_time_range():
+    # since/until で時間範囲を絞った後の service ユニーク数を返すこと。
+    # ts=110..140 → api(ts=110,120) + db(ts=130,140) = 2サービス
+    _seed_for_count()
+    resp = client.get("/metrics/count?since=110&until=140")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 4
+    assert data["services"] == 2
+
+
+def test_count_services_distinct_zero_when_status_excludes_all():
+    # status フィルタで該当 0 件になった場合、services も 0 を返すこと。
+    _seed_for_count()
+    # ストアに sub-status の record が無い healthy/unhealthy/degraded/unknown 以外は
+    # Literal で 422 になるため、ヒットしない status の代わりに service 名で絞る。
+    resp = client.get("/metrics/count?service=nonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["services"] == 0
+    # `by_status` のキー網羅は引き続き維持される
+    assert data["by_status"] == {
+        "healthy": 0, "unhealthy": 0, "degraded": 0, "unknown": 0,
+    }
 
 
 def test_list_services_latest_response_ms_single_observation():


### PR DESCRIPTION
## 概要

- `analytics-api` の `/metrics/count` のレスポンスに `services` (フィルタ通過後のレコードに登場した service 名のユニーク数) を追加
- 既存の `total` / `by_status` は破壊しない（追加フィールドのみ）
- `services` フィールドの境界条件をテスト追加（status フィルタ後 / 時間範囲フィルタ後 / ヒット 0 件）
- 既存の `/metrics/count` 全件・空ストア・service 絞り込みテストにも `services` の assert を追加
- README に `/metrics/count` の節を新設（既存表に行を追加 + サンプル curl + サンプルレスポンス + フィールド説明）

## 背景

ダッシュボード UI で「X サービス × Y チェック」のような全体サマリーを表示する際、現状は `/metrics/count` で件数を、`/metrics/services/names` で service 数を別々に取る必要があった。`/metrics/count` は元々 set 操作 1 回で済む軽量エンドポイントなので、`services` カウントもまとめて返す方が UI 側のリクエスト回数を 1 つ減らせる。

`/metrics?limit=1` 相当のメタデータだけ欲しい用途を想定しているため、ペイロード増加は数バイトに留まる。

Closes #87

## 動作確認

- [x] `flake8 --max-line-length=120 main.py` — エラー無し
- [x] `pytest -q` — 197 passed (既存 194 + 新規 3)
- [x] api-gateway は `/api/metrics/count` を `proxyAnalyticsGet` で透過転送しているため、gateway 側のコード変更なしで `services` フィールドが上流まで届くことを目視確認
- [x] `total` / `by_status` のスキーマは破壊していないことを既存の `/metrics/count` テスト群（全件 / 空ストア / service 絞り / status 絞り / 時間範囲 / q 部分一致 / 入力検証 400 / 422）で回帰確認