### PR TITLE
feat(analytics-api): /metrics/services/{service_name} に status_counts を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -263,6 +263,10 @@ class MetricsStore:
 
         total = len(records_snapshot)
         healthy = 0
+        # `ALLOWED_STATUSES` の全キーを 0 初期化することで、UI が
+        # 存在チェックなしで `status_counts.degraded` 等を参照できる。
+        # `/metrics/overview` の `status_counts` と同じ形を共有する。
+        status_counts: dict[str, int] = {s: 0 for s in ALLOWED_STATUSES}
         times: list[float] = []
         first_seen: float | None = None
         last_seen: float | None = None
@@ -271,6 +275,7 @@ class MetricsStore:
         for r in records_snapshot:
             if r.status == "healthy":
                 healthy += 1
+            status_counts[r.status] = status_counts.get(r.status, 0) + 1
             times.append(r.response_time_ms)
             if first_seen is None or r.timestamp < first_seen:
                 first_seen = r.timestamp
@@ -286,6 +291,7 @@ class MetricsStore:
             "total_checks": total,
             "healthy_checks": healthy,
             "uptime_pct": round(healthy / total * 100, 2),
+            "status_counts": status_counts,
             "first_seen": first_seen,
             "last_seen": last_seen,
             "latest_status": latest_status,

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -1765,6 +1765,77 @@ def test_get_service_detail_404_when_filter_excludes_all():
     assert resp.status_code == 404
 
 
+def test_get_service_detail_status_counts_initialized_for_all_statuses():
+    # 単一ステータスしか観測されていなくても、`status_counts` は全 4 ステータスを
+    # 0 初期化したマップで返す（UI が `status_counts.degraded` のように存在チェックなしで
+    # 参照できることを保証）。
+    client.post("/metrics", json={
+        "service": "api", "status": "healthy", "response_time_ms": 10.0,
+    })
+    resp = client.get("/metrics/services/api")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status_counts"] == {
+        "healthy": 1, "unhealthy": 0, "degraded": 0, "unknown": 0,
+    }
+
+
+def test_get_service_detail_status_counts_sum_matches_total_checks():
+    # `status_counts` の合計は `total_checks` と一致する。
+    # 4 ステータス全てを観測したパターンで確認する。
+    for status in ["healthy", "healthy", "unhealthy", "degraded", "unknown"]:
+        client.post("/metrics", json={
+            "service": "api", "status": status, "response_time_ms": 10.0,
+        })
+    resp = client.get("/metrics/services/api")
+    assert resp.status_code == 200
+    data = resp.json()
+    counts = data["status_counts"]
+    assert counts["healthy"] == 2
+    assert counts["unhealthy"] == 1
+    assert counts["degraded"] == 1
+    assert counts["unknown"] == 1
+    assert sum(counts.values()) == data["total_checks"] == 5
+    # `healthy_checks` は `status_counts.healthy` と一致する（既存値との整合性回帰）。
+    assert counts["healthy"] == data["healthy_checks"]
+
+
+def test_get_service_detail_status_counts_respects_time_filter():
+    # 時間範囲フィルタで除外されたレコードは `status_counts` にも含まれないこと。
+    client.post("/metrics", json={
+        "service": "web", "status": "unhealthy", "response_time_ms": 10.0, "timestamp": 50.0,
+    })
+    client.post("/metrics", json={
+        "service": "web", "status": "healthy", "response_time_ms": 20.0, "timestamp": 200.0,
+    })
+    resp = client.get("/metrics/services/web?since=100&until=300")
+    assert resp.status_code == 200
+    data = resp.json()
+    # since=100 より前の unhealthy=1 は含まれない
+    assert data["status_counts"] == {
+        "healthy": 1, "unhealthy": 0, "degraded": 0, "unknown": 0,
+    }
+    assert sum(data["status_counts"].values()) == data["total_checks"] == 1
+
+
+def test_get_service_detail_status_counts_excludes_other_services():
+    # 別 service のレコードは `status_counts` に含まれないこと。
+    client.post("/metrics", json={
+        "service": "api", "status": "healthy", "response_time_ms": 10.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "unhealthy", "response_time_ms": 500.0,
+    })
+    client.post("/metrics", json={
+        "service": "db", "status": "degraded", "response_time_ms": 100.0,
+    })
+    resp = client.get("/metrics/services/api")
+    data = resp.json()
+    assert data["status_counts"] == {
+        "healthy": 1, "unhealthy": 0, "degraded": 0, "unknown": 0,
+    }
+
+
 # ---------------------------------------------------------------------------
 # /metrics/timeseries — 時系列バケット集計
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

単一サービス詳細エンドポイント `/metrics/services/{service_name}` のレスポンスに、`status_counts: {healthy, unhealthy, degraded, unknown}` を追加した。`/metrics/overview` のレスポンスと同じく `ALLOWED_STATUSES` の全キーを 0 で初期化したマップとして返すため、UI 側は存在チェックなしで参照できる。

- `MetricsStore.service_detail()` のループ内でステータス別件数を集計
- レスポンスに `status_counts` を追加
- `status_counts.healthy` は既存の `healthy_checks` と一致、`status_counts` の合計は `total_checks` と一致（回帰テスト含む）

Closes #89

## 動作確認手順

- [x] `pip install -r requirements-dev.txt`
- [x] `flake8 --max-line-length=120 --exclude=__pycache__ main.py` がパス
- [x] `pytest -v` で全 201 ケースがパス（新規 4 ケース含む）
- [ ] `curl 'http://localhost:8001/metrics/services/api' | jq` でレスポンスに `status_counts` が含まれること