### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/status_changes を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -304,6 +304,49 @@ class MetricsStore:
             "p99_response_ms": round(_percentile(sorted_times, 99), 2),
         }
 
+    def status_changes(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[dict]:
+        """指定サービスの records を timestamp 昇順で走査し、
+        `status` が直前 observation と異なるイベントだけを抽出して返す。
+
+        各イベントの形:
+            {
+                "at": <変化が観測された Unix timestamp>,
+                "from_status": <直前 observation の status>,
+                "to_status": <現在 observation の status>,
+                "response_time_ms": <現在 observation の response_time_ms (小数点 2 桁)>,
+            }
+
+        初回 observation (直前が無い) は `from_status` が定義できないため
+        イベントとして扱わない。since/until は records レベルのフィルタ
+        として適用してから走査するため、ウィンドウ境界で「直前」が範囲外
+        にあっても結果が崩れない（その場合は「ウィンドウ内の最古」が
+        ベースラインとして扱われる）。
+
+        並び順は呼び元で `order` クエリ要求に従って必要なら反転する。
+        ここでは常に timestamp 昇順で返す。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        # filter() は records の挿入順（= 観測順）をそのまま保つが、
+        # 別経路で順序が崩れた場合の保険として timestamp 昇順でソートしておく。
+        records_snapshot.sort(key=lambda r: r.timestamp)
+        events: list[dict] = []
+        previous_status: str | None = None
+        for r in records_snapshot:
+            if previous_status is not None and r.status != previous_status:
+                events.append({
+                    "at": r.timestamp,
+                    "from_status": previous_status,
+                    "to_status": r.status,
+                    "response_time_ms": round(r.response_time_ms, 2),
+                })
+            previous_status = r.status
+        return events
+
     def has_records_for_service(
         self,
         service: str,
@@ -1187,6 +1230,101 @@ def get_service_timeseries(
         "bucket_seconds": bucket_seconds,
         "count": len(buckets),
         "buckets": buckets,
+    }
+
+
+@app.get("/metrics/services/{service_name}/status_changes")
+def get_service_status_changes(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみを対象にする",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみを対象にする",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（at の昇順 / 降順）",
+    ),
+):
+    """単一サービスのステータス遷移イベントを時系列順に返す。
+
+    `/metrics?service=X&sort=timestamp` をクライアント側で順次比較すれば等価な結果は
+    得られるが、ペイロード（全 observation）の転送コストが高く、ロジックが各 UI
+    に分散するのを避けるためサーバ側で集約する。
+
+    レスポンス:
+        {
+          "service": <service_name>,
+          "count": <ページ内件数>,
+          "total": <since/until 範囲内の遷移総数>,
+          "limit": <limit>,
+          "offset": <offset>,
+          "order": <"asc" or "desc">,
+          "changes": [
+            {"at": ..., "from_status": ..., "to_status": ..., "response_time_ms": ...},
+            ...
+          ]
+        }
+
+    変化点が 1 件も無い場合（観測が全て同じステータス、または observation が 1 件のみ）は
+    `total: 0` / `changes: []` を返す。ただし、対象サービスのレコードがウィンドウ範囲内
+    に 1 件も無い場合は 404 を返す（`/metrics/services/{service_name}` 等とセマンティクス
+    を揃える）。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    if not store.has_records_for_service(service=normalized, since=since, until=until):
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+
+    events = store.status_changes(service=normalized, since=since, until=until)
+    if order == "desc":
+        events.reverse()
+    total = len(events)
+    page = events[offset:offset + limit]
+    return {
+        "service": normalized,
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "order": order,
+        "changes": page,
     }
 
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2395,3 +2395,131 @@ def test_metrics_store_has_records_for_service_unit():
     assert s.has_records_for_service("web", since=50, until=150) is True
     assert s.has_records_for_service("web", since=500) is False
     assert s.has_records_for_service("web", until=50) is False
+
+
+# ---- /metrics/services/{service_name}/status_changes ----
+
+def _post_metric_with_timestamp(service: str, status: str, response_time_ms: float, ts: float):
+    resp = client.post(
+        "/metrics",
+        json={
+            "service": service,
+            "status": status,
+            "response_time_ms": response_time_ms,
+            "timestamp": ts,
+        },
+    )
+    assert resp.status_code == 201
+
+
+def test_service_status_changes_404_when_service_has_no_data():
+    resp = client.get("/metrics/services/missing/status_changes")
+    assert resp.status_code == 404
+
+
+def test_service_status_changes_empty_when_no_transitions():
+    # 全観測が同一ステータスなら遷移は 0 件だが、サービス自体は存在するので 200。
+    for ts in (100.0, 200.0, 300.0):
+        _post_metric_with_timestamp("web", "healthy", 10.0, ts)
+    resp = client.get("/metrics/services/web/status_changes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["total"] == 0
+    assert data["count"] == 0
+    assert data["changes"] == []
+
+
+def test_service_status_changes_returns_transitions_in_order():
+    # healthy -> unhealthy -> healthy の 2 回遷移
+    _post_metric_with_timestamp("web", "healthy", 10.0, 100.0)
+    _post_metric_with_timestamp("web", "healthy", 12.0, 150.0)
+    _post_metric_with_timestamp("web", "unhealthy", 1800.0, 200.0)
+    _post_metric_with_timestamp("web", "unhealthy", 1900.0, 250.0)
+    _post_metric_with_timestamp("web", "healthy", 120.0, 300.0)
+    resp = client.get("/metrics/services/web/status_changes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert data["count"] == 2
+    assert data["order"] == "asc"
+    changes = data["changes"]
+    assert changes[0]["at"] == 200.0
+    assert changes[0]["from_status"] == "healthy"
+    assert changes[0]["to_status"] == "unhealthy"
+    assert changes[0]["response_time_ms"] == 1800.0
+    assert changes[1]["at"] == 300.0
+    assert changes[1]["from_status"] == "unhealthy"
+    assert changes[1]["to_status"] == "healthy"
+    assert changes[1]["response_time_ms"] == 120.0
+
+
+def test_service_status_changes_order_desc():
+    _post_metric_with_timestamp("api", "healthy", 5.0, 10.0)
+    _post_metric_with_timestamp("api", "degraded", 80.0, 20.0)
+    _post_metric_with_timestamp("api", "unhealthy", 500.0, 30.0)
+    resp = client.get("/metrics/services/api/status_changes?order=desc")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert data["order"] == "desc"
+    assert data["changes"][0]["at"] == 30.0
+    assert data["changes"][0]["to_status"] == "unhealthy"
+    assert data["changes"][1]["at"] == 20.0
+
+
+def test_service_status_changes_since_until_filter():
+    # since/until でウィンドウ内に絞った場合、ウィンドウ内最古がベースライン扱いで
+    # それ以降の遷移だけが返る。
+    _post_metric_with_timestamp("db", "healthy", 5.0, 10.0)
+    _post_metric_with_timestamp("db", "unhealthy", 600.0, 20.0)  # 遷移1
+    _post_metric_with_timestamp("db", "unhealthy", 700.0, 30.0)
+    _post_metric_with_timestamp("db", "healthy", 12.0, 40.0)  # 遷移2
+    _post_metric_with_timestamp("db", "degraded", 250.0, 50.0)  # 遷移3
+    # since=25, until=45 → 観測は [30, 40] のみ。30 がベースラインなので 40 で遷移1件のみ。
+    resp = client.get("/metrics/services/db/status_changes?since=25&until=45")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["changes"][0]["at"] == 40.0
+    assert data["changes"][0]["from_status"] == "unhealthy"
+    assert data["changes"][0]["to_status"] == "healthy"
+
+
+def test_service_status_changes_pagination():
+    statuses = ["healthy", "unhealthy", "healthy", "unhealthy", "healthy"]
+    for i, st in enumerate(statuses):
+        _post_metric_with_timestamp("ws", st, float(10 + i), float(100 + i * 10))
+    resp = client.get("/metrics/services/ws/status_changes?limit=2&offset=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 4
+    assert data["count"] == 2
+    assert data["limit"] == 2
+    assert data["offset"] == 1
+
+
+def test_service_status_changes_rejects_since_greater_than_until():
+    _post_metric_with_timestamp("svc", "healthy", 1.0, 100.0)
+    resp = client.get("/metrics/services/svc/status_changes?since=500&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_status_changes_rejects_blank_path():
+    # path に空白だけを送ると 400
+    resp = client.get("/metrics/services/%20/status_changes")
+    assert resp.status_code == 400
+
+
+def test_metrics_store_status_changes_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=1.0, timestamp=10.0))
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=2.0, timestamp=20.0))
+    s.add(MetricRecord(service="web", status="unhealthy", response_time_ms=999.0, timestamp=30.0))
+    s.add(MetricRecord(service="other", status="healthy", response_time_ms=3.0, timestamp=25.0))
+    events = s.status_changes("web")
+    assert len(events) == 1
+    assert events[0]["at"] == 30.0
+    assert events[0]["from_status"] == "healthy"
+    assert events[0]["to_status"] == "unhealthy"
+    assert events[0]["response_time_ms"] == 999.0


### PR DESCRIPTION
## 概要

- 単一サービスのステータス遷移イベントを時系列順に返す新エンドポイント `GET /metrics/services/{service_name}/status_changes` を追加
- `from_status` / `to_status` / `at` / `response_time_ms` を含むイベント配列を返す（初回観測はベースライン扱いで含めない）
- `since` / `until` / `limit` / `offset` / `order` のクエリパラメータをサポート
- 該当サービスのレコードがウィンドウ内に 1 件もない場合は 404（既存 `service_detail` と同一セマンティクス）
- `MetricsStore.status_changes()` を新規追加し、ユニットテスト・統合テスト 9 ケースを追加

## 動作確認

- `flake8 --max-line-length=120 main.py` — pass
- `pytest -v` — 210 passed（うち新規 9 ケース）
- 観測が同一ステータスのみの場合に `total: 0` / `changes: []` を返すこと、since/until ウィンドウ内最古をベースラインとして扱うことを確認

## 対応 Issue

Closes #91