### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/by_status を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -347,6 +347,70 @@ class MetricsStore:
             previous_status = r.status
         return events
 
+    def service_by_status(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> dict | None:
+        """単一サービスの観測をステータス別にグルーピングして集計結果を返す。
+
+        `service_detail` は status_counts (件数のみ) を返すが、UI で
+        「healthy のとき p95=80ms、degraded のとき p95=2000ms」のように
+        ステータス別のレスポンス時間分布を見たい場合に使う。
+
+        全 `ALLOWED_STATUSES` をキーに含み（観測 0 件のステータスも `count=0` で埋める）、
+        UI 側で存在チェックなしで参照できるようにする。各ステータスのブロックは:
+            count / avg_response_ms / min_response_ms / max_response_ms /
+            p50_response_ms / p95_response_ms / p99_response_ms /
+            first_seen / last_seen
+
+        観測 0 件のステータスのレスポンス時間統計は `0.0`、`first_seen` / `last_seen`
+        は `None` を返す（`/metrics/overview` の percentile が空集合で 0.0 を返す挙動と整合）。
+        対象サービスのレコードが (since/until 範囲内に) 1 件も無い場合は `None` を返す。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        if not records_snapshot:
+            return None
+
+        per_status: dict[str, dict] = {
+            s: {"times": [], "first_seen": None, "last_seen": None}
+            for s in ALLOWED_STATUSES
+        }
+        for r in records_snapshot:
+            bucket = per_status.setdefault(
+                r.status,
+                {"times": [], "first_seen": None, "last_seen": None},
+            )
+            bucket["times"].append(r.response_time_ms)
+            if bucket["first_seen"] is None or r.timestamp < bucket["first_seen"]:
+                bucket["first_seen"] = r.timestamp
+            if bucket["last_seen"] is None or r.timestamp > bucket["last_seen"]:
+                bucket["last_seen"] = r.timestamp
+
+        by_status: dict[str, dict] = {}
+        for status_name, bucket in per_status.items():
+            times = bucket["times"]
+            sorted_times = sorted(times)
+            count = len(sorted_times)
+            avg = sum(times) / count if count else 0.0
+            by_status[status_name] = {
+                "count": count,
+                "avg_response_ms": round(avg, 2),
+                "min_response_ms": round(sorted_times[0], 2) if sorted_times else 0.0,
+                "max_response_ms": round(sorted_times[-1], 2) if sorted_times else 0.0,
+                "p50_response_ms": round(_percentile(sorted_times, 50), 2),
+                "p95_response_ms": round(_percentile(sorted_times, 95), 2),
+                "p99_response_ms": round(_percentile(sorted_times, 99), 2),
+                "first_seen": bucket["first_seen"],
+                "last_seen": bucket["last_seen"],
+            }
+        return {
+            "service": service,
+            "total": len(records_snapshot),
+            "by_status": by_status,
+        }
+
     def has_records_for_service(
         self,
         service: str,
@@ -1326,6 +1390,73 @@ def get_service_status_changes(
         "order": order,
         "changes": page,
     }
+
+
+@app.get("/metrics/services/{service_name}/by_status")
+def get_service_by_status(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+):
+    """単一サービスの観測を `status` 別にグルーピングしてレスポンス時間統計を返す。
+
+    既存 `/metrics/services/{service_name}` は `status_counts`（件数のみ）と全体の
+    percentile を返すが、「healthy のとき p95=80ms / degraded のとき p95=2000ms」のように
+    ステータスごとのレスポンス時間分布を可視化したい場面では情報が足りなかった。
+    本エンドポイントは各ステータスについて count / avg / min / max / p50 / p95 / p99 /
+    first_seen / last_seen を返し、UI 側で 1 リクエストでドリルダウン表示を可能にする。
+
+    レスポンス:
+        {
+          "service": <service_name>,
+          "total": <since/until 範囲内の全 observation 件数>,
+          "by_status": {
+            "healthy":   {count, avg_response_ms, min, max, p50, p95, p99, first_seen, last_seen},
+            "unhealthy": {...},
+            "degraded":  {...},
+            "unknown":   {...}
+          }
+        }
+
+    `by_status` は `ALLOWED_STATUSES` の全キーを必ず含み、観測 0 件のステータスでも
+    count=0 / 統計 0.0 / first_seen=last_seen=null を埋めるため、UI は存在チェック不要。
+    対象サービスのレコードが範囲内に 1 件も無い場合は 404 を返す
+    （`/metrics/services/{service_name}` 等とセマンティクスを揃える）。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    detail = store.service_by_status(service=normalized, since=since, until=until)
+    if detail is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return detail
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2523,3 +2523,126 @@ def test_metrics_store_status_changes_unit():
     assert events[0]["from_status"] == "healthy"
     assert events[0]["to_status"] == "unhealthy"
     assert events[0]["response_time_ms"] == 999.0
+
+
+# ---- /metrics/services/{service_name}/by_status ----
+
+def test_service_by_status_basic():
+    _post_metric_with_timestamp("web", "healthy", 50.0, 10.0)
+    _post_metric_with_timestamp("web", "healthy", 60.0, 20.0)
+    _post_metric_with_timestamp("web", "degraded", 500.0, 30.0)
+    _post_metric_with_timestamp("other", "healthy", 1.0, 40.0)
+    resp = client.get("/metrics/services/web/by_status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["total"] == 3
+    by = data["by_status"]
+    # 全 ALLOWED_STATUSES が必ず存在
+    assert set(by.keys()) == {"healthy", "unhealthy", "degraded", "unknown"}
+    assert by["healthy"]["count"] == 2
+    assert by["degraded"]["count"] == 1
+    assert by["unhealthy"]["count"] == 0
+    assert by["unknown"]["count"] == 0
+    assert by["healthy"]["avg_response_ms"] == 55.0
+    assert by["healthy"]["min_response_ms"] == 50.0
+    assert by["healthy"]["max_response_ms"] == 60.0
+    assert by["healthy"]["first_seen"] == 10.0
+    assert by["healthy"]["last_seen"] == 20.0
+    assert by["degraded"]["first_seen"] == 30.0
+    assert by["degraded"]["last_seen"] == 30.0
+
+
+def test_service_by_status_empty_status_block_has_zeros():
+    _post_metric_with_timestamp("svc", "healthy", 10.0, 1.0)
+    resp = client.get("/metrics/services/svc/by_status")
+    body = resp.json()["by_status"]
+    for status_name in ("unhealthy", "degraded", "unknown"):
+        assert body[status_name]["count"] == 0
+        assert body[status_name]["avg_response_ms"] == 0.0
+        assert body[status_name]["min_response_ms"] == 0.0
+        assert body[status_name]["max_response_ms"] == 0.0
+        assert body[status_name]["p50_response_ms"] == 0.0
+        assert body[status_name]["p95_response_ms"] == 0.0
+        assert body[status_name]["p99_response_ms"] == 0.0
+        assert body[status_name]["first_seen"] is None
+        assert body[status_name]["last_seen"] is None
+
+
+def test_service_by_status_404_when_no_records():
+    resp = client.get("/metrics/services/missing/by_status")
+    assert resp.status_code == 404
+
+
+def test_service_by_status_404_when_only_other_services():
+    _post_metric_with_timestamp("other", "healthy", 1.0, 1.0)
+    resp = client.get("/metrics/services/web/by_status")
+    assert resp.status_code == 404
+
+
+def test_service_by_status_since_until_filter():
+    _post_metric_with_timestamp("web", "healthy", 10.0, 5.0)
+    _post_metric_with_timestamp("web", "degraded", 200.0, 50.0)
+    _post_metric_with_timestamp("web", "healthy", 11.0, 95.0)
+    resp = client.get("/metrics/services/web/by_status?since=10&until=80")
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["by_status"]["degraded"]["count"] == 1
+    assert body["by_status"]["healthy"]["count"] == 0
+
+
+def test_service_by_status_404_when_filter_excludes_all():
+    _post_metric_with_timestamp("web", "healthy", 1.0, 100.0)
+    resp = client.get("/metrics/services/web/by_status?since=200")
+    assert resp.status_code == 404
+
+
+def test_service_by_status_rejects_since_greater_than_until():
+    _post_metric_with_timestamp("svc", "healthy", 1.0, 100.0)
+    resp = client.get("/metrics/services/svc/by_status?since=500&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_by_status_rejects_blank_path():
+    resp = client.get("/metrics/services/%20/by_status")
+    assert resp.status_code == 400
+
+
+def test_service_by_status_percentiles_single_value():
+    # 1 件のみだと p50=p95=p99=min=max=avg
+    _post_metric_with_timestamp("web", "healthy", 42.0, 10.0)
+    body = client.get("/metrics/services/web/by_status").json()
+    h = body["by_status"]["healthy"]
+    assert h["count"] == 1
+    assert h["p50_response_ms"] == 42.0
+    assert h["p95_response_ms"] == 42.0
+    assert h["p99_response_ms"] == 42.0
+    assert h["avg_response_ms"] == 42.0
+    assert h["min_response_ms"] == 42.0
+    assert h["max_response_ms"] == 42.0
+
+
+def test_service_by_status_mixed_statuses_independent_percentiles():
+    # healthy: 10, 20, 30 → p50=20
+    _post_metric_with_timestamp("web", "healthy", 10.0, 1.0)
+    _post_metric_with_timestamp("web", "healthy", 20.0, 2.0)
+    _post_metric_with_timestamp("web", "healthy", 30.0, 3.0)
+    # degraded: 1000, 2000 → p50=1500
+    _post_metric_with_timestamp("web", "degraded", 1000.0, 4.0)
+    _post_metric_with_timestamp("web", "degraded", 2000.0, 5.0)
+    body = client.get("/metrics/services/web/by_status").json()
+    assert body["by_status"]["healthy"]["p50_response_ms"] == 20.0
+    assert body["by_status"]["degraded"]["p50_response_ms"] == 1500.0
+
+
+def test_metrics_store_service_by_status_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=50.0, timestamp=10.0))
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=500.0, timestamp=20.0))
+    s.add(MetricRecord(service="other", status="healthy", response_time_ms=1.0, timestamp=30.0))
+    result = s.service_by_status("web")
+    assert result is not None
+    assert result["total"] == 2
+    assert result["by_status"]["healthy"]["count"] == 1
+    assert result["by_status"]["degraded"]["count"] == 1
+    assert s.service_by_status("missing") is None


### PR DESCRIPTION
## 概要

単一サービスの観測を `status` 別にグルーピングしてレスポンス時間統計を返す `GET /metrics/services/{service_name}/by_status` を追加します。

- `by_status` は `ALLOWED_STATUSES` (`healthy` / `unhealthy` / `degraded` / `unknown`) の全キーを必ず含む（観測 0 件のステータスも `count=0` で埋める）
- 各ステータスごとに `count` / `avg` / `min` / `max` / `p50` / `p95` / `p99` / `first_seen` / `last_seen` を返す
- 対象サービスのレコードが range 内に 1 件も無い場合は 404（`/metrics/services/{service_name}` 等とセマンティクスを揃える）
- `MetricsStore.service_by_status()` を追加し、既存 `_percentile` ヘルパでパーセンタイルを計算

Close #93

## 動作確認

- [x] `pytest -v` 全 221 件パス（新規 11 件追加）
- [x] `flake8 --max-line-length=120 --exclude=__pycache__ main.py` 警告なし
- [x] 既存エンドポイント (`/metrics/services/{service_name}` 等) への影響なし

## 動作例

```
POST /metrics  {service:web, status:healthy,  response_time_ms:50,  timestamp:10}
POST /metrics  {service:web, status:healthy,  response_time_ms:60,  timestamp:20}
POST /metrics  {service:web, status:degraded, response_time_ms:500, timestamp:30}

GET /metrics/services/web/by_status
{
  "service": "web",
  "total": 3,
  "by_status": {
    "healthy":   {"count": 2, "avg_response_ms": 55.0, "min_response_ms": 50.0, "max_response_ms": 60.0, "p50_response_ms": 55.0, "p95_response_ms": 59.5, "p99_response_ms": 59.9, "first_seen": 10.0, "last_seen": 20.0},
    "unhealthy": {"count": 0, "avg_response_ms": 0.0, ..., "first_seen": null, "last_seen": null},
    "degraded":  {"count": 1, "avg_response_ms": 500.0, "first_seen": 30.0, "last_seen": 30.0, ...},
    "unknown":   {"count": 0, ...}
  }
}
```
