### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/latest を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Response:
 | GET | `/metrics/count` | フィルタ後のレコード件数・status 別件数・登場サービス数のみを返す軽量エンドポイント（`?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/metrics/services/{service_name}/timeseries` | 単一サービスに絞った時系列バケット集計（`?bucket_seconds=` / `?status=` / `?since=` / `?until=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/latest` | 単一サービスの直近 1 件の observation を `{service, status, response_time_ms, timestamp}` 形で返す軽量エンドポイント（`?since=` / `?until=`）。該当サービスが存在しなければ 404 |
 
 #### Delete Metrics
 

--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -411,6 +411,32 @@ class MetricsStore:
             "by_status": by_status,
         }
 
+    def latest_for_service(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> MetricRecord | None:
+        """対象サービスの since/until 範囲内で最新（timestamp 最大）の observation を返す。
+
+        範囲内にレコードが無ければ `None`。同 timestamp の重複時は、`add()` の挿入順を
+        保つため後勝ち（= 同 timestamp の最後に追加された observation を返す）とする。
+        ダッシュボードのバッジ表示など「直近 1 件だけ欲しい」用途向け。
+        """
+        with self._lock:
+            snapshot = list(self.records)
+        latest: MetricRecord | None = None
+        for r in snapshot:
+            if r.service != service:
+                continue
+            if since is not None and r.timestamp < since:
+                continue
+            if until is not None and r.timestamp > until:
+                continue
+            if latest is None or r.timestamp >= latest.timestamp:
+                latest = r
+        return latest
+
     def has_records_for_service(
         self,
         service: str,
@@ -1217,6 +1243,63 @@ def get_service_detail(
             detail=f"No metrics found for service '{normalized}'",
         )
     return detail
+
+
+@app.get("/metrics/services/{service_name}/latest")
+def get_service_latest(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の observation のみ対象",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の observation のみ対象",
+    ),
+):
+    """単一サービスの最新 observation 1 件を `{service, status, response_time_ms, timestamp}` で返す。
+
+    `GET /metrics/services/{service_name}` はフル集約 (percentile / status_counts / uptime_pct)
+    を返すため「現在のステータス・直近の応答時間だけを見たい」UI 用途では過剰。
+    本エンドポイントはレスポンス時間統計や集計を計算せず、対象範囲内で `timestamp` 最大
+    の 1 件をそのまま返す軽量エンドポイント。
+
+    `since` / `until` クエリで対象範囲を絞れる（他の `/metrics/services/{name}/*` と整合）。
+    範囲内にレコードが 1 件も無い場合は 404。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    latest = store.latest_for_service(service=normalized, since=since, until=until)
+    if latest is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return {
+        "service": latest.service,
+        "status": latest.status,
+        "response_time_ms": round(latest.response_time_ms, 2),
+        "timestamp": latest.timestamp,
+    }
 
 
 @app.get("/metrics/services/{service_name}/timeseries")

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2646,3 +2646,111 @@ def test_metrics_store_service_by_status_unit():
     assert result["by_status"]["healthy"]["count"] == 1
     assert result["by_status"]["degraded"]["count"] == 1
     assert s.service_by_status("missing") is None
+
+
+# ---- /metrics/services/{service_name}/latest ----
+
+
+def _post(service: str, status: str, response_time_ms: float, timestamp: float) -> None:
+    """テスト用の直接 store 投入ヘルパ。POST 経路を経由しないため、
+    explicit な timestamp を強制でき、テストの順序依存を避けられる。"""
+    store.add(
+        MetricRecord(
+            service=service,
+            status=status,
+            response_time_ms=response_time_ms,
+            timestamp=timestamp,
+        )
+    )
+
+
+def test_service_latest_returns_most_recent_record():
+    # 同サービス内で最新 timestamp のレコードが返る。
+    _post("web", "healthy", 12.5, 10.0)
+    _post("web", "degraded", 800.0, 30.0)
+    _post("web", "unhealthy", 1500.0, 20.0)
+    resp = client.get("/metrics/services/web/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "service": "web",
+        "status": "degraded",
+        "response_time_ms": 800.0,
+        "timestamp": 30.0,
+    }
+
+
+def test_service_latest_ignores_other_services():
+    # 別 service のレコードは候補から除外される。
+    _post("api", "healthy", 10.0, 1000.0)
+    _post("web", "unhealthy", 50.0, 999.0)
+    resp = client.get("/metrics/services/web/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["timestamp"] == 999.0
+
+
+def test_service_latest_404_when_service_has_no_records():
+    _post("api", "healthy", 10.0, 1000.0)
+    resp = client.get("/metrics/services/missing/latest")
+    assert resp.status_code == 404
+    assert "missing" in resp.json()["detail"]
+
+
+def test_service_latest_404_when_range_excludes_all_records():
+    # since/until を当てると範囲外になり 404 になる。
+    _post("web", "healthy", 10.0, 100.0)
+    resp = client.get("/metrics/services/web/latest?since=200&until=300")
+    assert resp.status_code == 404
+
+
+def test_service_latest_since_until_filter():
+    # 範囲内のみから最新が選ばれる。
+    _post("web", "healthy", 10.0, 50.0)
+    _post("web", "degraded", 800.0, 100.0)
+    _post("web", "unhealthy", 1500.0, 200.0)
+    resp = client.get("/metrics/services/web/latest?since=60&until=150")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["timestamp"] == 100.0
+    assert data["status"] == "degraded"
+
+
+def test_service_latest_rejects_since_greater_than_until():
+    resp = client.get("/metrics/services/web/latest?since=500&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_latest_rejects_negative_since():
+    resp = client.get("/metrics/services/web/latest?since=-1")
+    assert resp.status_code == 422
+
+
+def test_service_latest_rejects_blank_service_name():
+    # %20 を path に入れると "  " として渡るので strip 後に空になる。
+    resp = client.get("/metrics/services/%20/latest")
+    assert resp.status_code == 400
+
+
+def test_service_latest_round_trips_response_time():
+    # response_time_ms は小数点 2 桁丸めで返る（store の挙動と整合）。
+    _post("web", "healthy", 12.345, 10.0)
+    resp = client.get("/metrics/services/web/latest")
+    assert resp.status_code == 200
+    assert resp.json()["response_time_ms"] == 12.35
+
+
+def test_metrics_store_latest_for_service_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=20.0, timestamp=3.0))
+    s.add(MetricRecord(service="api", status="healthy", response_time_ms=5.0, timestamp=2.0))
+    latest = s.latest_for_service("web")
+    assert latest is not None
+    assert latest.timestamp == 3.0
+    assert latest.status == "degraded"
+    # 範囲外なら None
+    assert s.latest_for_service("web", since=10.0) is None
+    # 該当サービス無しなら None
+    assert s.latest_for_service("missing") is None


### PR DESCRIPTION
## 変更概要

- `MetricsStore.latest_for_service(service, since, until)` を新設。範囲内の最大 timestamp を持つ observation を 1 件返す（無ければ `None`）。
- `GET /metrics/services/{service_name}/latest` を追加。レスポンスは `{service, status, response_time_ms, timestamp}` の 1 オブジェクト。`since` / `until` で範囲を絞れる。
  - `since > until` / 非有限値は 400。
  - `service_name` の空白・長さは 400。
  - 範囲内にレコードが無ければ 404。
- `test_main.py` に 10 件のテストを追加（最新の選択ロジック・別 service 排除・404 系・範囲フィルタ・small 浮動小数の丸め・store 単体）。
- README のエンドポイント表に追記。

Closes #95

## 動作確認手順

```bash
cd analytics-api
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
```

手動確認:

```bash
curl -X POST -H 'content-type: application/json' \
  -d '{"service":"web","status":"degraded","response_time_ms":800.0,"timestamp":30}' \
  http://localhost:8001/metrics
curl http://localhost:8001/metrics/services/web/latest
# => {"service":"web","status":"degraded","response_time_ms":800.0,"timestamp":30.0}
```