### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/recent を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -437,6 +437,42 @@ class MetricsStore:
                 latest = r
         return latest
 
+    def recent_for_service(
+        self,
+        service: str,
+        limit: int,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[MetricRecord]:
+        """対象サービスの since/until 範囲内で `timestamp` 降順の直近 `limit` 件を返す。
+
+        ダッシュボードのサービス詳細画面の「最近の N 件のチェック履歴」用途向け。
+        `service_detail` の percentile / status_counts / uptime_pct を計算しないため
+        軽量で、`latest_for_service` の N 件版に相当する。
+
+        同 timestamp の重複は `add()` の挿入順を保つ（`latest_for_service` の後勝ち
+        セマンティクスと同じく、同 timestamp は「より後に追加された方が新しい」と扱う）。
+        範囲内のレコードが `limit` 未満ならその分だけ返す。`limit <= 0` の場合は空配列。
+        """
+        if limit <= 0:
+            return []
+        with self._lock:
+            snapshot = list(self.records)
+        # filter は service / since / until のみ反映。q / status は本ヘルパーでは
+        # 受け取らない（呼び元エンドポイントの仕様）。
+        candidates: list[tuple[int, MetricRecord]] = []
+        for idx, r in enumerate(snapshot):
+            if r.service != service:
+                continue
+            if since is not None and r.timestamp < since:
+                continue
+            if until is not None and r.timestamp > until:
+                continue
+            candidates.append((idx, r))
+        # timestamp 降順、同 timestamp は挿入順の後（= idx が大きい方）を先に。
+        candidates.sort(key=lambda t: (t[1].timestamp, t[0]), reverse=True)
+        return [r for _, r in candidates[:limit]]
+
     def has_records_for_service(
         self,
         service: str,
@@ -1299,6 +1335,79 @@ def get_service_latest(
         "status": latest.status,
         "response_time_ms": round(latest.response_time_ms, 2),
         "timestamp": latest.timestamp,
+    }
+
+
+@app.get("/metrics/services/{service_name}/recent")
+def get_service_recent(
+    service_name: str,
+    limit: int = Query(
+        default=10,
+        ge=1,
+        le=200,
+        description="返す observation 件数の上限（1〜200）。",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の observation のみ対象",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の observation のみ対象",
+    ),
+):
+    """単一サービスの直近 N 件の observation を `timestamp` 降順で返す。
+
+    `/metrics/services/{service_name}` はフル集約 (percentile / uptime_pct / status_counts)
+    を計算するため、ダッシュボードの「最近のチェック履歴」一覧用途には過剰。
+    本エンドポイントは生 observation を新しい順に返すだけで、集計は一切しない。
+
+    `since` / `until` クエリで対象範囲を絞れる（他の `/metrics/services/{name}/*` と整合）。
+    範囲内にレコードが 1 件も無い場合は 404。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    items = store.recent_for_service(
+        service=normalized,
+        limit=limit,
+        since=since,
+        until=until,
+    )
+    if not items:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return {
+        "service": normalized,
+        "count": len(items),
+        "items": [
+            {
+                "status": r.status,
+                "response_time_ms": round(r.response_time_ms, 2),
+                "timestamp": r.timestamp,
+            }
+            for r in items
+        ],
     }
 
 

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2754,3 +2754,147 @@ def test_metrics_store_latest_for_service_unit():
     assert s.latest_for_service("web", since=10.0) is None
     # 該当サービス無しなら None
     assert s.latest_for_service("missing") is None
+
+
+# ---- /metrics/services/{service_name}/recent ----
+
+
+def test_service_recent_returns_records_in_desc_order():
+    # 同サービスの観測を timestamp 降順で返す。
+    _post("web", "healthy", 12.5, 10.0)
+    _post("web", "unhealthy", 1500.0, 30.0)
+    _post("web", "degraded", 800.0, 20.0)
+    resp = client.get("/metrics/services/web/recent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["count"] == 3
+    assert [item["timestamp"] for item in data["items"]] == [30.0, 20.0, 10.0]
+    assert [item["status"] for item in data["items"]] == ["unhealthy", "degraded", "healthy"]
+
+
+def test_service_recent_respects_limit():
+    # limit より多い observation がある場合、先頭 limit 件だけ返る。
+    for ts in range(1, 11):
+        _post("web", "healthy", 10.0, float(ts))
+    resp = client.get("/metrics/services/web/recent?limit=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 3
+    assert [item["timestamp"] for item in data["items"]] == [10.0, 9.0, 8.0]
+
+
+def test_service_recent_default_limit_is_10():
+    # limit を渡さなければデフォルト 10 件まで。
+    for ts in range(1, 21):
+        _post("web", "healthy", 10.0, float(ts))
+    resp = client.get("/metrics/services/web/recent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 10
+    assert data["items"][0]["timestamp"] == 20.0
+    assert data["items"][-1]["timestamp"] == 11.0
+
+
+def test_service_recent_ignores_other_services():
+    # 別 service のレコードは無視される。
+    _post("api", "healthy", 10.0, 1000.0)
+    _post("web", "unhealthy", 50.0, 999.0)
+    _post("web", "degraded", 25.0, 998.0)
+    resp = client.get("/metrics/services/web/recent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert all(item["timestamp"] in (999.0, 998.0) for item in data["items"])
+    assert data["count"] == 2
+
+
+def test_service_recent_404_when_service_has_no_records():
+    _post("api", "healthy", 10.0, 1000.0)
+    resp = client.get("/metrics/services/missing/recent")
+    assert resp.status_code == 404
+    assert "missing" in resp.json()["detail"]
+
+
+def test_service_recent_404_when_range_excludes_all_records():
+    _post("web", "healthy", 10.0, 100.0)
+    resp = client.get("/metrics/services/web/recent?since=200&until=300")
+    assert resp.status_code == 404
+
+
+def test_service_recent_since_until_filter():
+    # 範囲内のみから直近順に返る。
+    _post("web", "healthy", 10.0, 50.0)
+    _post("web", "degraded", 800.0, 100.0)
+    _post("web", "unhealthy", 1500.0, 200.0)
+    _post("web", "healthy", 12.0, 80.0)
+    resp = client.get("/metrics/services/web/recent?since=60&until=150")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [item["timestamp"] for item in data["items"]] == [100.0, 80.0]
+
+
+def test_service_recent_rejects_since_greater_than_until():
+    resp = client.get("/metrics/services/web/recent?since=500&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_recent_rejects_negative_since():
+    resp = client.get("/metrics/services/web/recent?since=-1")
+    assert resp.status_code == 422
+
+
+def test_service_recent_rejects_limit_above_cap():
+    # `le=200` を超える limit は 422 で弾かれる。
+    resp = client.get("/metrics/services/web/recent?limit=999")
+    assert resp.status_code == 422
+
+
+def test_service_recent_rejects_limit_zero():
+    # `ge=1` を満たさない limit=0 は 422 で弾かれる。
+    resp = client.get("/metrics/services/web/recent?limit=0")
+    assert resp.status_code == 422
+
+
+def test_service_recent_rejects_blank_service_name():
+    resp = client.get("/metrics/services/%20/recent")
+    assert resp.status_code == 400
+
+
+def test_service_recent_round_trips_response_time():
+    # response_time_ms は小数点 2 桁丸めで返る（store の挙動と整合）。
+    _post("web", "healthy", 12.345, 10.0)
+    resp = client.get("/metrics/services/web/recent")
+    assert resp.status_code == 200
+    assert resp.json()["items"][0]["response_time_ms"] == 12.35
+
+
+def test_service_recent_same_timestamp_uses_insertion_order():
+    # 同 timestamp の重複は挿入順の後（latest_for_service と同じ後勝ち順）が先頭。
+    _post("web", "healthy", 1.0, 50.0)
+    _post("web", "degraded", 2.0, 50.0)
+    _post("web", "unhealthy", 3.0, 50.0)
+    resp = client.get("/metrics/services/web/recent?limit=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    # 同 timestamp なので response_time_ms で区別。後に挿入された順に返る。
+    assert [item["response_time_ms"] for item in data["items"]] == [3.0, 2.0, 1.0]
+
+
+def test_metrics_store_recent_for_service_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=20.0, timestamp=3.0))
+    s.add(MetricRecord(service="web", status="unhealthy", response_time_ms=30.0, timestamp=2.0))
+    s.add(MetricRecord(service="api", status="healthy", response_time_ms=5.0, timestamp=4.0))
+    result = s.recent_for_service("web", limit=10)
+    assert [r.timestamp for r in result] == [3.0, 2.0, 1.0]
+    # limit クランプ
+    result = s.recent_for_service("web", limit=2)
+    assert [r.timestamp for r in result] == [3.0, 2.0]
+    # 範囲外なら空
+    assert s.recent_for_service("web", limit=10, since=10.0) == []
+    # 該当サービス無しなら空
+    assert s.recent_for_service("missing", limit=10) == []
+    # limit=0 は空
+    assert s.recent_for_service("web", limit=0) == []


### PR DESCRIPTION
## 概要

- 単一サービスの直近 N 件の生 observation を `timestamp` 降順で返す `GET /metrics/services/{service_name}/recent` を追加
- レスポンス形: `{service, count, items: [{status, response_time_ms, timestamp}, ...]}`
- パラメータ: `limit` (default=10, ge=1, le=200), `since`, `until`
- データ無しは 404、since>until は 400、limit/since レンジ外は 422（既存 `/latest` と同じ）
- 同 timestamp の重複は `add()` 挿入順の後勝ち（`latest_for_service` と同セマンティクス）
- `MetricsStore.recent_for_service` を追加し、テストでカバー

## 動作確認手順

- `cd analytics-api && flake8 --max-line-length=120 --exclude=__pycache__ main.py` — クリーン
- `cd analytics-api && pytest -v` — 既存 232 件 + 新規 14 件 = 246 件すべてパス（ローカルで確認済）
- 手動: `curl 'http://localhost:8000/metrics/services/web/recent?limit=5'` で新しい順 5 件が返ることを確認

Closes #97
