### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/incidents を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -411,6 +411,85 @@ class MetricsStore:
             "by_status": by_status,
         }
 
+    def incidents(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[dict]:
+        """対象サービスの records を timestamp 昇順で走査し、
+        `healthy` 以外のステータスが連続する区間を 1 つのインシデントへ畳んで返す。
+
+        各インシデントの形:
+            {
+                "started_at": <最初の非 healthy observation の timestamp>,
+                "ended_at": <最後の非 healthy observation の timestamp>,
+                "duration_seconds": <ended_at - started_at>,
+                "ongoing": <ウィンドウ末端まで非 healthy が続いた場合 True>,
+                "statuses": [<observation で観測された非 healthy ステータスの集合をソート>],
+                "observation_count": <インシデント中の observation 件数>,
+                "max_response_time_ms": <インシデント中の最大 response_time (小数点 2 桁)>,
+            }
+
+        ウィンドウ境界で「直前の healthy」が範囲外にあっても結果が崩れないよう、
+        since/until は records レベルのフィルタとして適用してから走査する
+        （= ウィンドウ内最古の observation がインシデント start として扱われる）。
+
+        並び順は常に `started_at` 昇順。呼び元で `order` クエリ要求に従って反転する。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        records_snapshot.sort(key=lambda r: r.timestamp)
+
+        incidents_out: list[dict] = []
+        cur_start: float | None = None
+        cur_end: float | None = None
+        cur_statuses: set[str] = set()
+        cur_count = 0
+        cur_max_rt = 0.0
+
+        def _flush(ongoing: bool) -> None:
+            # cur_start / cur_end が None のときには呼ばれない前提。
+            duration = 0.0
+            if cur_end is not None and cur_start is not None:
+                duration = cur_end - cur_start
+            incidents_out.append({
+                "started_at": cur_start,
+                "ended_at": cur_end,
+                "duration_seconds": round(duration, 2),
+                "ongoing": ongoing,
+                "statuses": sorted(cur_statuses),
+                "observation_count": cur_count,
+                "max_response_time_ms": round(cur_max_rt, 2),
+            })
+
+        for r in records_snapshot:
+            if r.status != "healthy":
+                if cur_start is None:
+                    cur_start = r.timestamp
+                    cur_end = r.timestamp
+                    cur_statuses = {r.status}
+                    cur_count = 1
+                    cur_max_rt = r.response_time_ms
+                else:
+                    cur_end = r.timestamp
+                    cur_statuses.add(r.status)
+                    cur_count += 1
+                    if r.response_time_ms > cur_max_rt:
+                        cur_max_rt = r.response_time_ms
+            else:
+                if cur_start is not None:
+                    _flush(ongoing=False)
+                    cur_start = None
+                    cur_end = None
+                    cur_statuses = set()
+                    cur_count = 0
+                    cur_max_rt = 0.0
+
+        if cur_start is not None:
+            _flush(ongoing=True)
+
+        return incidents_out
+
     def latest_for_service(
         self,
         service: str,
@@ -1649,6 +1728,107 @@ def get_service_by_status(
             detail=f"No metrics found for service '{normalized}'",
         )
     return detail
+
+
+@app.get("/metrics/services/{service_name}/incidents")
+def get_service_incidents(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ対象",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ対象",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（started_at の昇順 / 降順）",
+    ),
+):
+    """単一サービスの「`healthy` 以外が連続した期間」をインシデントとして時系列順に返す。
+
+    `/metrics/services/{service_name}/status_changes` は遷移点のリストを返すが、
+    各 UI で隣り合う `healthy→non-healthy→healthy` を 1 イベントへ畳む必要があり、
+    集計ロジックが各クライアントに分散していた。本エンドポイントはサーバ側で
+    インシデント単位に集約し、`started_at` / `ended_at` / `duration_seconds` /
+    `ongoing` / `statuses` / `observation_count` / `max_response_time_ms` を返す。
+
+    レスポンス:
+        {
+          "service": <service_name>,
+          "count":  <ページ内件数>,
+          "total":  <ウィンドウ内のインシデント総数>,
+          "limit":  <limit>,
+          "offset": <offset>,
+          "order":  <"asc" or "desc">,
+          "incidents": [
+            {"started_at", "ended_at", "duration_seconds", "ongoing",
+             "statuses", "observation_count", "max_response_time_ms"},
+            ...
+          ]
+        }
+
+    インシデントが 1 件も無い（全 observation が `healthy`）場合は `total: 0`,
+    `incidents: []`。対象サービスのレコードが範囲内に 1 件も無い場合は 404 を返す
+    （他の `/metrics/services/{name}/*` とセマンティクスを揃える）。
+
+    `ongoing` はウィンドウ末端まで非 healthy が続いた場合に True。ウィンドウ外で
+    のちに healthy へ戻った可能性は判定できないため、「ウィンドウ内では未終了」
+    という意味で扱う。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    if not store.has_records_for_service(service=normalized, since=since, until=until):
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+
+    incidents_list = store.incidents(service=normalized, since=since, until=until)
+    if order == "desc":
+        incidents_list.reverse()
+    total = len(incidents_list)
+    page = incidents_list[offset:offset + limit]
+    return {
+        "service": normalized,
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "order": order,
+        "incidents": page,
+    }
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2898,3 +2898,175 @@ def test_metrics_store_recent_for_service_unit():
     assert s.recent_for_service("missing", limit=10) == []
     # limit=0 は空
     assert s.recent_for_service("web", limit=0) == []
+
+
+# ---- /metrics/services/{service_name}/incidents ----
+
+
+def test_service_incidents_returns_404_when_no_records():
+    resp = client.get("/metrics/services/missing/incidents")
+    assert resp.status_code == 404
+
+
+def test_service_incidents_all_healthy_returns_empty_list():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "healthy", 11.0, 2.0)
+    resp = client.get("/metrics/services/web/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["total"] == 0
+    assert data["count"] == 0
+    assert data["incidents"] == []
+
+
+def test_service_incidents_collapses_consecutive_non_healthy_run():
+    # healthy → unhealthy → degraded → healthy で 1 インシデント。
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 200.0, 2.0)
+    _post("web", "degraded", 500.0, 3.0)
+    _post("web", "healthy", 12.0, 4.0)
+    resp = client.get("/metrics/services/web/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    inc = data["incidents"][0]
+    assert inc["started_at"] == 2.0
+    assert inc["ended_at"] == 3.0
+    assert inc["duration_seconds"] == 1.0
+    assert inc["ongoing"] is False
+    assert inc["statuses"] == ["degraded", "unhealthy"]
+    assert inc["observation_count"] == 2
+    # max は inc 中の最大 response_time
+    assert inc["max_response_time_ms"] == 500.0
+
+
+def test_service_incidents_separates_two_incidents_with_healthy_between():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("web", "degraded", 800.0, 4.0)
+    _post("web", "healthy", 12.0, 5.0)
+    resp = client.get("/metrics/services/web/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert data["incidents"][0]["started_at"] == 2.0
+    assert data["incidents"][0]["statuses"] == ["unhealthy"]
+    assert data["incidents"][1]["started_at"] == 4.0
+    assert data["incidents"][1]["statuses"] == ["degraded"]
+    assert all(inc["ongoing"] is False for inc in data["incidents"])
+
+
+def test_service_incidents_ongoing_when_window_ends_in_non_healthy():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 300.0, 2.0)
+    _post("web", "unhealthy", 350.0, 3.0)
+    resp = client.get("/metrics/services/web/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    inc = data["incidents"][0]
+    assert inc["started_at"] == 2.0
+    assert inc["ended_at"] == 3.0
+    assert inc["ongoing"] is True
+    assert inc["observation_count"] == 2
+    assert inc["max_response_time_ms"] == 350.0
+
+
+def test_service_incidents_starts_at_first_non_healthy_when_window_begins_in_outage():
+    # ウィンドウ先頭が非 healthy で始まるケース。直前の healthy が無くても
+    # ウィンドウ内最古の非 healthy observation を start として扱う。
+    _post("web", "degraded", 600.0, 1.0)
+    _post("web", "unhealthy", 700.0, 2.0)
+    _post("web", "healthy", 10.0, 3.0)
+    resp = client.get("/metrics/services/web/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    inc = data["incidents"][0]
+    assert inc["started_at"] == 1.0
+    assert inc["ended_at"] == 2.0
+    assert inc["ongoing"] is False
+    assert inc["statuses"] == ["degraded", "unhealthy"]
+
+
+def test_service_incidents_respects_since_until():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("web", "degraded", 800.0, 4.0)
+    _post("web", "healthy", 12.0, 5.0)
+    # since=3 から見ると 1 件目のインシデント (t=2) は範囲外。
+    resp = client.get("/metrics/services/web/incidents?since=3")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["incidents"][0]["started_at"] == 4.0
+
+
+def test_service_incidents_order_desc():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("web", "degraded", 800.0, 4.0)
+    _post("web", "healthy", 12.0, 5.0)
+    resp = client.get("/metrics/services/web/incidents?order=desc")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["order"] == "desc"
+    assert [inc["started_at"] for inc in data["incidents"]] == [4.0, 2.0]
+
+
+def test_service_incidents_limit_and_offset():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("web", "degraded", 200.0, 4.0)
+    _post("web", "healthy", 12.0, 5.0)
+    _post("web", "unhealthy", 300.0, 6.0)
+    _post("web", "healthy", 13.0, 7.0)
+    resp = client.get("/metrics/services/web/incidents?limit=1&offset=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["count"] == 1
+    assert data["limit"] == 1
+    assert data["offset"] == 1
+    # offset=1 番目（asc）→ t=4 のインシデント
+    assert data["incidents"][0]["started_at"] == 4.0
+
+
+def test_service_incidents_rejects_since_greater_than_until():
+    _post("web", "unhealthy", 100.0, 5.0)
+    resp = client.get("/metrics/services/web/incidents?since=10&until=5")
+    assert resp.status_code == 400
+
+
+def test_service_incidents_rejects_blank_service_name():
+    resp = client.get("/metrics/services/%20/incidents")
+    assert resp.status_code == 400
+
+
+def test_service_incidents_rejects_limit_zero():
+    resp = client.get("/metrics/services/web/incidents?limit=0")
+    assert resp.status_code == 422
+
+
+def test_metrics_store_incidents_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    s.add(MetricRecord(service="web", status="unhealthy", response_time_ms=200.0, timestamp=2.0))
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=500.0, timestamp=3.0))
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=4.0))
+    s.add(MetricRecord(service="api", status="unhealthy", response_time_ms=999.0, timestamp=2.0))
+    incidents = s.incidents("web")
+    assert len(incidents) == 1
+    inc = incidents[0]
+    assert inc["started_at"] == 2.0
+    assert inc["ended_at"] == 3.0
+    assert inc["duration_seconds"] == 1.0
+    assert inc["ongoing"] is False
+    assert inc["statuses"] == ["degraded", "unhealthy"]
+    assert inc["observation_count"] == 2
+    assert inc["max_response_time_ms"] == 500.0


### PR DESCRIPTION
## 変更概要

- `MetricsStore.incidents(service, since, until)` を追加: records を timestamp 昇順で走査し、`healthy` 以外が連続する区間を 1 インシデントへ畳む（`started_at` / `ended_at` / `duration_seconds` / `ongoing` / `statuses` / `observation_count` / `max_response_time_ms`）
- `GET /metrics/services/{service_name}/incidents` を追加。`since`/`until` ウィンドウ、`limit`/`offset`、`order=asc|desc` を他 per-service エンドポイントと同型に提供。
- 通常検出 / 複数分離 / ongoing / 全 healthy 空配列 / ウィンドウ先頭で outage / since 絞り込み / order=desc / limit&offset / 不正パラメータの回帰テストを 12 件追加（store ユニットテスト含む）

## 対応 Issue

Closes #99

## 動作確認手順

1. `cd analytics-api && pip install -r requirements-dev.txt`
2. `flake8 --max-line-length=120 --exclude=__pycache__ main.py`
3. `pytest -v`（追加した 12 件含めて 259 件パス）
4. ローカル起動 `python main.py` → `curl 'http://localhost:8001/metrics/services/web/incidents'` で挙動を目視確認