### PR TITLE
feat(analytics-api): GET /metrics/services/{service_name}/uptime を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -490,6 +490,61 @@ class MetricsStore:
 
         return incidents_out
 
+    def uptime(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> dict | None:
+        """単一サービスの SLA 観点の集約値を返す。レコードが 1 件も無ければ None。
+
+        `service_detail()` の `uptime_pct`（observation 件数ベース）に加えて、
+        `incidents()` から得られるインシデント時間ベースの SLA 指標を 1 オブジェクトで返す。
+
+        各値:
+            - total_checks / healthy_checks / uptime_pct: チェック件数ベース
+            - incident_count: 非 healthy の連続区間の数
+            - ongoing_incident: ウィンドウ末端で incident が継続中か
+            - total_incident_seconds: 全 incident の duration の合計（小数点 2 桁）
+            - longest_incident_seconds: 最長 incident の duration
+            - mean_incident_seconds: incident 平均長（MTTR 相当, incident_count==0 なら 0.0）
+
+        ダッシュボードの SLA ウィジェット用に「件数ベースの uptime_pct と、
+        インシデント単位の MTTR」を 1 リクエストで一括取得する用途を想定する。
+        個別 incident のリストが必要な場合は `/incidents`、status_counts や percentile
+        が必要な場合は `/services/{name}` を併用する（intentional 分離）。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        if not records_snapshot:
+            return None
+
+        total = len(records_snapshot)
+        healthy = sum(1 for r in records_snapshot if r.status == "healthy")
+        incidents_list = self.incidents(service=service, since=since, until=until)
+        incident_count = len(incidents_list)
+        if incident_count == 0:
+            total_incident_seconds = 0.0
+            longest_incident_seconds = 0.0
+            mean_incident_seconds = 0.0
+            ongoing_incident = False
+        else:
+            durations = [float(inc["duration_seconds"]) for inc in incidents_list]
+            total_incident_seconds = sum(durations)
+            longest_incident_seconds = max(durations)
+            mean_incident_seconds = total_incident_seconds / incident_count
+            ongoing_incident = bool(incidents_list[-1]["ongoing"])
+        return {
+            "service": service,
+            "total_checks": total,
+            "healthy_checks": healthy,
+            "uptime_pct": round(healthy / total * 100, 2),
+            "incident_count": incident_count,
+            "ongoing_incident": ongoing_incident,
+            "total_incident_seconds": round(total_incident_seconds, 2),
+            "longest_incident_seconds": round(longest_incident_seconds, 2),
+            "mean_incident_seconds": round(mean_incident_seconds, 2),
+        }
+
     def latest_for_service(
         self,
         service: str,
@@ -1829,6 +1884,74 @@ def get_service_incidents(
         "order": order,
         "incidents": page,
     }
+
+
+@app.get("/metrics/services/{service_name}/uptime")
+def get_service_uptime(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+):
+    """単一サービスの SLA 集約値を返す。
+
+    既存:
+        - `/metrics/services/{service_name}` は uptime_pct (件数ベース) のみ
+        - `/metrics/services/{service_name}/incidents` は incident のリスト
+    の 2 つを SRE ダッシュボードで結合する利用が増えたため、件数ベースの
+    uptime_pct とインシデント単位の SLA 指標 (incident_count / total_incident_seconds /
+    longest_incident_seconds / mean_incident_seconds / ongoing_incident) を 1 リクエストに
+    集約する。
+
+    レスポンス:
+        {
+          "service": <service_name>,
+          "total_checks": <int>,
+          "healthy_checks": <int>,
+          "uptime_pct": <float>,
+          "incident_count": <int>,
+          "ongoing_incident": <bool>,
+          "total_incident_seconds": <float>,
+          "longest_incident_seconds": <float>,
+          "mean_incident_seconds": <float>
+        }
+
+    対象サービスのレコードが範囲内に 1 件も無い場合は 404 を返す
+    （他の `/metrics/services/{name}/*` とセマンティクスを揃える）。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    detail = store.uptime(service=normalized, since=since, until=until)
+    if detail is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return detail
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -3070,3 +3070,153 @@ def test_metrics_store_incidents_unit():
     assert inc["statuses"] == ["degraded", "unhealthy"]
     assert inc["observation_count"] == 2
     assert inc["max_response_time_ms"] == 500.0
+
+
+# ---- /metrics/services/{service_name}/uptime ----
+
+
+def test_service_uptime_404_when_no_records():
+    resp = client.get("/metrics/services/missing/uptime")
+    assert resp.status_code == 404
+    assert "missing" in resp.json()["detail"]
+
+
+def test_service_uptime_all_healthy_returns_zero_incidents():
+    _post("web", "healthy", 12.0, 10.0)
+    _post("web", "healthy", 13.0, 20.0)
+    _post("web", "healthy", 14.0, 30.0)
+    resp = client.get("/metrics/services/web/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "service": "web",
+        "total_checks": 3,
+        "healthy_checks": 3,
+        "uptime_pct": 100.0,
+        "incident_count": 0,
+        "ongoing_incident": False,
+        "total_incident_seconds": 0.0,
+        "longest_incident_seconds": 0.0,
+        "mean_incident_seconds": 0.0,
+    }
+
+
+def test_service_uptime_single_resolved_incident():
+    # healthy -> unhealthy -> degraded -> healthy のシーケンスは
+    # 1 incident (started_at=2.0, ended_at=3.0, duration=1.0) に畳まれる。
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 200.0, 2.0)
+    _post("web", "degraded", 500.0, 3.0)
+    _post("web", "healthy", 10.0, 4.0)
+    resp = client.get("/metrics/services/web/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["total_checks"] == 4
+    assert data["healthy_checks"] == 2
+    assert data["uptime_pct"] == 50.0
+    assert data["incident_count"] == 1
+    assert data["ongoing_incident"] is False
+    assert data["total_incident_seconds"] == 1.0
+    assert data["longest_incident_seconds"] == 1.0
+    assert data["mean_incident_seconds"] == 1.0
+
+
+def test_service_uptime_multiple_incidents_mean_and_longest():
+    # 2 件の incident:
+    #   1) t=2..3 (duration=1.0, healthy at t=10 で resolve)
+    #   2) t=20..25 (duration=5.0, healthy at t=30 で resolve)
+    # mean=3.0, longest=5.0, total=6.0
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 200.0, 2.0)
+    _post("web", "unhealthy", 200.0, 3.0)
+    _post("web", "healthy", 10.0, 10.0)
+    _post("web", "degraded", 200.0, 20.0)
+    _post("web", "unhealthy", 300.0, 25.0)
+    _post("web", "healthy", 10.0, 30.0)
+    resp = client.get("/metrics/services/web/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["incident_count"] == 2
+    assert data["ongoing_incident"] is False
+    assert data["longest_incident_seconds"] == 5.0
+    assert data["total_incident_seconds"] == 6.0
+    assert data["mean_incident_seconds"] == 3.0
+
+
+def test_service_uptime_ongoing_when_window_ends_in_non_healthy():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 200.0, 2.0)
+    _post("web", "unhealthy", 200.0, 5.0)
+    resp = client.get("/metrics/services/web/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["incident_count"] == 1
+    assert data["ongoing_incident"] is True
+    assert data["longest_incident_seconds"] == 3.0
+
+
+def test_service_uptime_respects_since_until():
+    # since/until で範囲外を除外したときに件数とインシデントが整合する。
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 200.0, 50.0)
+    _post("web", "healthy", 10.0, 51.0)
+    _post("web", "unhealthy", 200.0, 200.0)
+    resp = client.get("/metrics/services/web/uptime?since=40&until=60")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_checks"] == 2
+    assert data["healthy_checks"] == 1
+    assert data["incident_count"] == 1
+
+
+def test_service_uptime_rejects_since_greater_than_until():
+    _post("web", "healthy", 10.0, 1.0)
+    resp = client.get("/metrics/services/web/uptime?since=100&until=50")
+    assert resp.status_code == 400
+
+
+def test_service_uptime_rejects_blank_service_name():
+    resp = client.get("/metrics/services/%20/uptime")
+    assert resp.status_code == 400
+
+
+def test_service_uptime_rejects_too_long_service_name():
+    long_name = "a" * 300
+    resp = client.get(f"/metrics/services/{long_name}/uptime")
+    assert resp.status_code == 400
+
+
+def test_service_uptime_ignores_other_services():
+    _post("api", "unhealthy", 500.0, 10.0)
+    _post("web", "healthy", 10.0, 11.0)
+    _post("web", "healthy", 10.0, 12.0)
+    resp = client.get("/metrics/services/web/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["incident_count"] == 0
+    assert data["uptime_pct"] == 100.0
+
+
+def test_metrics_store_uptime_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    s.add(MetricRecord(service="web", status="unhealthy", response_time_ms=200.0, timestamp=2.0))
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=500.0, timestamp=4.0))
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=5.0))
+    result = s.uptime("web")
+    assert result is not None
+    assert result["total_checks"] == 4
+    assert result["healthy_checks"] == 2
+    assert result["uptime_pct"] == 50.0
+    assert result["incident_count"] == 1
+    assert result["ongoing_incident"] is False
+    assert result["total_incident_seconds"] == 2.0
+    assert result["longest_incident_seconds"] == 2.0
+    assert result["mean_incident_seconds"] == 2.0
+
+
+def test_metrics_store_uptime_none_when_no_records():
+    s = MetricsStore()
+    s.add(MetricRecord(service="api", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    assert s.uptime("missing") is None


### PR DESCRIPTION
## 概要

単一サービスの SLA 集約値を 1 リクエストで返す新規エンドポイントを追加。件数ベースの `uptime_pct` とインシデント単位の `incident_count` / `total_incident_seconds` / `longest_incident_seconds` / `mean_incident_seconds`（MTTR 相当）/ `ongoing_incident` をまとめて返す。

## 変更点

- `MetricsStore.uptime(service, since, until)` を実装
- `GET /metrics/services/{service_name}/uptime` ルート追加
- テスト 11 件追加（HTTP 9 件 + store 単体 2 件）

## レスポンス例

```json
{
  "service": "web",
  "total_checks": 4,
  "healthy_checks": 2,
  "uptime_pct": 50.0,
  "incident_count": 1,
  "ongoing_incident": false,
  "total_incident_seconds": 1.0,
  "longest_incident_seconds": 1.0,
  "mean_incident_seconds": 1.0
}
```

## 動作確認

- [x] `flake8 --max-line-length=120 --exclude=__pycache__ main.py` 通過
- [x] `pytest -q` 271 passed（既存 259 + 新規 12 - 注: incident のテスト体系と被らないよう uptime 系のみ）

Closes #101