### PR TITLE
feat(analytics-api): 全サービス横断インシデント一覧 GET /metrics/incidents を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -490,6 +490,41 @@ class MetricsStore:
 
         return incidents_out
 
+    def all_incidents(
+        self,
+        service: str | None = None,
+        q: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[dict]:
+        """フィルタ条件に一致する全サービスのインシデントを横断的に返す。
+
+        `incidents()` が単一サービスの非 healthy 連続区間を抽出するのに対し、
+        本メソッドは複数サービスを横断して各インシデントに `service` フィールドを
+        付与した辞書を返す。SRE ダッシュボードの「現在発生中・直近のインシデント」
+        全体ビュー（特定サービスを跨いだ俯瞰）の単一リクエスト化を想定。
+
+        フィルタの意味:
+            - service: 指定された場合は単一サービスのみ対象（per-service と等価）
+            - q: フィルタ後の service 名に対する部分一致（大文字小文字無視）
+            - since/until: 観測の Unix timestamp ウィンドウ
+
+        並び順は呼び出し側で決める前提でここでは `started_at` 昇順を返す
+        （同一 `started_at` の場合は `service` 名の辞書順をタイブレーカに使う）。
+        """
+        if service is not None:
+            services = [service]
+        else:
+            services = self.distinct_services(since=since, until=until, q=q)
+        out: list[dict] = []
+        for svc in services:
+            for inc in self.incidents(service=svc, since=since, until=until):
+                # `service` 列を先頭に置いて他のフィールドはそのまま残す。
+                enriched = {"service": svc, **inc}
+                out.append(enriched)
+        out.sort(key=lambda d: (d["started_at"], d["service"]))
+        return out
+
     def uptime(
         self,
         service: str,
@@ -1877,6 +1912,125 @@ def get_service_incidents(
     page = incidents_list[offset:offset + limit]
     return {
         "service": normalized,
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "order": order,
+        "incidents": page,
+    }
+
+
+@app.get("/metrics/incidents")
+def get_all_incidents(
+    service: str | None = Query(
+        default=None,
+        description="単一サービスのみに絞り込む場合に指定（per-service 版と等価）",
+    ),
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する部分一致フィルタ（大文字小文字無視）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ対象",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ対象",
+    ),
+    ongoing_only: bool = Query(
+        default=False,
+        description="True ならウィンドウ末端で継続中（ongoing）のインシデントのみを返す",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（started_at の昇順 / 降順）",
+    ),
+):
+    """全サービス横断のインシデント一覧。
+
+    `/metrics/services/{service_name}/incidents` は単一サービス単位だが、
+    SRE ダッシュボードの「今どこかで障害が起きているか」を見たい場面では
+    クライアント側で `/metrics/services/names` → 各サービス毎の
+    `/metrics/services/{name}/incidents` を fan-out する必要があった。
+    本エンドポイントはサーバ側で全サービスを横断集計し、各インシデントに
+    `service` 列を付けて返す。
+
+    レスポンス:
+        {
+          "count":  <ページ内件数>,
+          "total":  <フィルタ後のインシデント総数>,
+          "limit":  <limit>,
+          "offset": <offset>,
+          "order":  <"asc" or "desc">,
+          "incidents": [
+            {"service", "started_at", "ended_at", "duration_seconds", "ongoing",
+             "statuses", "observation_count", "max_response_time_ms"},
+            ...
+          ]
+        }
+
+    `service` クエリを指定した場合は単一サービスのみ対象（`/metrics/services/
+    {service_name}/incidents` と同等の絞り込み）。`q` は service 名への部分一致
+    フィルタ（`/metrics/overview` 等と同じセマンティクス）。`ongoing_only=true`
+    の場合はウィンドウ末端まで非 healthy が続いている現在進行中のインシデント
+    だけを返す。
+
+    並びは `started_at` 昇順をベースに、同 timestamp は `service` 名でタイブレーク。
+    `order=desc` を指定するとリストを反転して返す。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized_service: str | None = None
+    if service is not None:
+        normalized_service = service.strip()
+        if not normalized_service:
+            raise HTTPException(status_code=400, detail="service must not be blank")
+        if len(normalized_service) > MAX_SERVICE_LENGTH:
+            raise HTTPException(
+                status_code=400,
+                detail=f"service must be at most {MAX_SERVICE_LENGTH} characters",
+            )
+
+    normalized_q, q_error = _normalize_q_param(q)
+    if q_error is not None:
+        raise HTTPException(status_code=400, detail=q_error)
+
+    incidents_list = store.all_incidents(
+        service=normalized_service,
+        q=normalized_q,
+        since=since,
+        until=until,
+    )
+    if ongoing_only:
+        incidents_list = [inc for inc in incidents_list if inc.get("ongoing")]
+    if order == "desc":
+        incidents_list.reverse()
+    total = len(incidents_list)
+    page = incidents_list[offset:offset + limit]
+    return {
         "count": len(page),
         "total": total,
         "limit": limit,

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -3220,3 +3220,189 @@ def test_metrics_store_uptime_none_when_no_records():
     s = MetricsStore()
     s.add(MetricRecord(service="api", status="healthy", response_time_ms=10.0, timestamp=1.0))
     assert s.uptime("missing") is None
+
+
+# ----------------------------------------------------------------------
+# GET /metrics/incidents (cross-service)
+# ----------------------------------------------------------------------
+
+
+def test_all_incidents_empty_store_returns_empty_list():
+    resp = client.get("/metrics/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["count"] == 0
+    assert data["limit"] >= 1
+    assert data["offset"] == 0
+    assert data["order"] == "asc"
+    assert data["incidents"] == []
+
+
+def test_all_incidents_aggregates_across_services_sorted_asc():
+    # web: incident at t=2
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    # db: incident at t=4
+    _post("db", "healthy", 20.0, 1.0)
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "healthy", 22.0, 5.0)
+    resp = client.get("/metrics/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    assert data["count"] == 2
+    services = [inc["service"] for inc in data["incidents"]]
+    starts = [inc["started_at"] for inc in data["incidents"]]
+    # asc order by started_at: web (t=2) first, then db (t=4)
+    assert starts == [2.0, 4.0]
+    assert services == ["web", "db"]
+
+
+def test_all_incidents_tiebreak_by_service_name():
+    # 同じ started_at の場合は service 名の辞書順でタイブレーク（昇順）。
+    _post("alpha", "unhealthy", 100.0, 5.0)
+    _post("alpha", "healthy", 10.0, 6.0)
+    _post("zeta", "unhealthy", 100.0, 5.0)
+    _post("zeta", "healthy", 10.0, 6.0)
+    resp = client.get("/metrics/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    services = [inc["service"] for inc in data["incidents"]]
+    assert services == ["alpha", "zeta"]
+
+
+def test_all_incidents_filters_by_service():
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "healthy", 22.0, 5.0)
+    resp = client.get("/metrics/incidents?service=web")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["incidents"][0]["service"] == "web"
+    assert data["incidents"][0]["started_at"] == 2.0
+
+
+def test_all_incidents_filters_by_q_substring_case_insensitive():
+    _post("web-api", "unhealthy", 100.0, 2.0)
+    _post("web-api", "healthy", 11.0, 3.0)
+    _post("db-primary", "degraded", 800.0, 4.0)
+    _post("db-primary", "healthy", 22.0, 5.0)
+    resp = client.get("/metrics/incidents?q=WEB")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["incidents"][0]["service"] == "web-api"
+
+
+def test_all_incidents_filters_by_time_range():
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("db", "degraded", 800.0, 10.0)
+    _post("db", "healthy", 22.0, 11.0)
+    resp = client.get("/metrics/incidents?since=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["incidents"][0]["service"] == "db"
+
+
+def test_all_incidents_ongoing_only_filter():
+    # web: closed incident (healthy follows)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    # db: ongoing incident (window ends in non-healthy)
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "unhealthy", 900.0, 5.0)
+    resp = client.get("/metrics/incidents?ongoing_only=true")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    inc = data["incidents"][0]
+    assert inc["service"] == "db"
+    assert inc["ongoing"] is True
+
+
+def test_all_incidents_order_desc_reverses_list():
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "healthy", 22.0, 5.0)
+    resp = client.get("/metrics/incidents?order=desc")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["order"] == "desc"
+    starts = [inc["started_at"] for inc in data["incidents"]]
+    assert starts == [4.0, 2.0]
+
+
+def test_all_incidents_pagination_limit_and_offset():
+    # 3 つのインシデントを作る
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "healthy", 22.0, 5.0)
+    _post("cache", "unhealthy", 50.0, 6.0)
+    _post("cache", "healthy", 5.0, 7.0)
+    resp = client.get("/metrics/incidents?limit=1&offset=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["count"] == 1
+    assert data["limit"] == 1
+    assert data["offset"] == 1
+    # asc 順で 2 件目 → db (t=4)
+    assert data["incidents"][0]["service"] == "db"
+
+
+def test_all_incidents_rejects_invalid_range():
+    resp = client.get("/metrics/incidents?since=10&until=5")
+    assert resp.status_code == 400
+
+
+def test_all_incidents_rejects_blank_service():
+    resp = client.get("/metrics/incidents?service=%20%20")
+    assert resp.status_code == 400
+
+
+def test_all_incidents_rejects_blank_q():
+    resp = client.get("/metrics/incidents?q=%20%20")
+    assert resp.status_code == 400
+
+
+def test_all_incidents_rejects_zero_limit():
+    resp = client.get("/metrics/incidents?limit=0")
+    assert resp.status_code == 422
+
+
+def test_all_incidents_no_incidents_when_all_healthy():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "healthy", 11.0, 2.0)
+    _post("db", "healthy", 20.0, 1.0)
+    resp = client.get("/metrics/incidents")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["incidents"] == []
+
+
+def test_metrics_store_all_incidents_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="unhealthy", response_time_ms=100.0, timestamp=2.0))
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=3.0))
+    s.add(MetricRecord(service="db", status="degraded", response_time_ms=500.0, timestamp=4.0))
+    result = s.all_incidents()
+    assert len(result) == 2
+    # asc by started_at
+    assert result[0]["service"] == "web"
+    assert result[0]["started_at"] == 2.0
+    assert result[1]["service"] == "db"
+    assert result[1]["started_at"] == 4.0
+    # service フィールドが先頭で付与されている
+    assert "service" in result[0]
+    assert "started_at" in result[0]
+    assert "duration_seconds" in result[0]


### PR DESCRIPTION
## 変更概要

- `MetricsStore.all_incidents(service=None, q=None, since=None, until=None)` を新設し、フィルタ後の全サービスを横断して既存 `incidents()` の結果に `service` 列を付与した辞書リストを返す（タイブレークは service 名）
- `GET /metrics/incidents` を追加。クエリ `service` / `q` / `since` / `until` / `ongoing_only` / `limit` / `offset` / `order` を実装し、既存エンドポイントとセマンティクスを揃える
- バリデーション: since>until → 400、since/until 非有限 → 400、blank service → 400、blank q / 長過ぎ q → 400、limit=0 → 422
- テスト 15 ケース追加（集約・タイブレーク・service/q フィルタ・時刻範囲・ongoing_only・order=desc・pagination・各エラー系・空ストア・MetricsStore ユニット）

## 対応 Issue

Closes #103

## 動作確認手順

```bash
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
```

ローカルで全 286 件パス。

## サンプル

```
GET /metrics/incidents?ongoing_only=true&order=desc&limit=20
{
  "count": 1, "total": 1, "limit": 20, "offset": 0, "order": "desc",
  "incidents": [
    {"service": "db", "started_at": 4.0, "ended_at": 5.0,
     "duration_seconds": 1.0, "ongoing": true,
     "statuses": ["degraded", "unhealthy"],
     "observation_count": 2, "max_response_time_ms": 900.0}
  ]
}
```
