### PR TITLE
feat(analytics-api): 全サービス横断 SLA 集約 GET /metrics/uptime を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -580,6 +580,38 @@ class MetricsStore:
             "mean_incident_seconds": round(mean_incident_seconds, 2),
         }
 
+    def all_uptime(
+        self,
+        q: str | None = None,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> list[dict]:
+        """全サービス横断の SLA 集約値リストを返す。
+
+        `uptime()` が単一サービスを返すのに対し、本メソッドは `distinct_services()` で
+        フィルタ通過後の service 名一覧を取り、各サービスに対し `uptime()` を呼んで
+        結果を集約する。`uptime()` が None を返すサービス（範囲内にレコードが無い）は
+        結果に含めない。
+
+        SRE ダッシュボードの「サービス一覧 + 各サービスの uptime / MTTR / 進行中
+        インシデント」全体ビューの単一リクエスト化を想定（`/metrics/incidents` の
+        SLA 集約版に相当する）。
+
+        並び順:
+            uptime_pct 昇順をベースに、同 uptime_pct はサービス名昇順をタイブレーカ
+            (= 悪い uptime を先頭に持ってくる方が SRE ダッシュボードでは有用)。
+            呼び出し側で必要なら反転する。
+        """
+        services = self.distinct_services(since=since, until=until, q=q)
+        out: list[dict] = []
+        for svc in services:
+            detail = self.uptime(service=svc, since=since, until=until)
+            if detail is None:
+                continue
+            out.append(detail)
+        out.sort(key=lambda d: (d["uptime_pct"], d["service"]))
+        return out
+
     def latest_for_service(
         self,
         service: str,
@@ -2106,6 +2138,102 @@ def get_service_uptime(
             detail=f"No metrics found for service '{normalized}'",
         )
     return detail
+
+
+@app.get("/metrics/uptime")
+def get_all_uptime(
+    q: str | None = Query(
+        default=None,
+        description="service 名に対する部分一致フィルタ（大文字小文字無視）",
+    ),
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+    ongoing_only: bool = Query(
+        default=False,
+        description="True ならウィンドウ末端で進行中インシデントを持つサービスのみ返す",
+    ),
+    limit: int = Query(
+        default=METRICS_DEFAULT_LIMIT,
+        ge=1,
+        le=METRICS_MAX_LIMIT,
+        description=f"返却件数上限（最大 {METRICS_MAX_LIMIT}）",
+    ),
+    offset: int = Query(
+        default=0,
+        ge=0,
+        description="先頭から読み飛ばす件数",
+    ),
+    order: SortOrderLiteral = Query(
+        default="asc",
+        description="ソート順（uptime_pct 昇順 = asc は worst-first、降順 = desc は best-first）",
+    ),
+):
+    """全サービス横断の SLA 集約一覧。
+
+    `/metrics/services/{service_name}/uptime` は単一サービス単位だが、
+    SRE ダッシュボードの「全サービスの uptime / MTTR / 進行中インシデント」
+    ビューでは `/metrics/services/names` → 各サービス毎の `/uptime` の fan-out が
+    必要だった。本エンドポイントはサーバ側で全サービスを横断集計し、各サービスの
+    SLA 集約値を 1 リクエストで返す（`/metrics/incidents` の SLA 集約版）。
+
+    レスポンス:
+        {
+          "count":  <ページ内件数>,
+          "total":  <フィルタ後のサービス数>,
+          "limit":  <limit>,
+          "offset": <offset>,
+          "order":  <"asc" or "desc">,
+          "services": [
+            {"service", "total_checks", "healthy_checks", "uptime_pct",
+             "incident_count", "ongoing_incident", "total_incident_seconds",
+             "longest_incident_seconds", "mean_incident_seconds"},
+            ...
+          ]
+        }
+
+    並びは uptime_pct 昇順をベースに、同 uptime_pct は service 名でタイブレーク。
+    `asc`（既定）は worst-uptime 先頭、`desc` は best-uptime 先頭。
+    `ongoing_only=true` でフィルタすると `ongoing_incident=true` のサービスだけを返す。
+    範囲内にレコードが 1 件も無いサービスは結果に含めない（`/uptime` の per-service
+    版が 404 を返すケースに相当）。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized_q, q_error = _normalize_q_param(q)
+    if q_error is not None:
+        raise HTTPException(status_code=400, detail=q_error)
+
+    services_list = store.all_uptime(q=normalized_q, since=since, until=until)
+    if ongoing_only:
+        services_list = [s for s in services_list if s.get("ongoing_incident")]
+    if order == "desc":
+        services_list = list(reversed(services_list))
+    total = len(services_list)
+    page = services_list[offset:offset + limit]
+    return {
+        "count": len(page),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "order": order,
+        "services": page,
+    }
 
 
 if __name__ == "__main__":

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -3406,3 +3406,183 @@ def test_metrics_store_all_incidents_unit():
     assert "service" in result[0]
     assert "started_at" in result[0]
     assert "duration_seconds" in result[0]
+
+
+# ----------------------------------------------------------------------
+# GET /metrics/uptime (cross-service SLA)
+# ----------------------------------------------------------------------
+
+
+def test_all_uptime_empty_store_returns_empty_list():
+    resp = client.get("/metrics/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["count"] == 0
+    assert data["limit"] >= 1
+    assert data["offset"] == 0
+    assert data["order"] == "asc"
+    assert data["services"] == []
+
+
+def test_all_uptime_aggregates_each_service_with_full_fields():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "healthy", 11.0, 2.0)
+    _post("db", "healthy", 20.0, 1.0)
+    _post("db", "unhealthy", 800.0, 2.0)
+    _post("db", "healthy", 22.0, 3.0)
+    resp = client.get("/metrics/uptime")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 2
+    # asc by uptime_pct: db (66.67%) は web (100%) より低いので先頭
+    db_entry = next(s for s in data["services"] if s["service"] == "db")
+    web_entry = next(s for s in data["services"] if s["service"] == "web")
+    assert data["services"][0]["service"] == "db"
+    assert data["services"][1]["service"] == "web"
+    # 全フィールド存在チェック
+    for key in (
+        "service", "total_checks", "healthy_checks", "uptime_pct",
+        "incident_count", "ongoing_incident", "total_incident_seconds",
+        "longest_incident_seconds", "mean_incident_seconds",
+    ):
+        assert key in db_entry
+        assert key in web_entry
+    assert web_entry["uptime_pct"] == 100.0
+    assert web_entry["incident_count"] == 0
+    assert db_entry["incident_count"] == 1
+
+
+def test_all_uptime_sorted_uptime_pct_then_service_name():
+    # web と cache がともに 50% uptime → service 名昇順で cache が先
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("cache", "healthy", 5.0, 1.0)
+    _post("cache", "unhealthy", 50.0, 2.0)
+    # db は 100%
+    _post("db", "healthy", 20.0, 1.0)
+    resp = client.get("/metrics/uptime")
+    services = [s["service"] for s in resp.json()["services"]]
+    # 50% タイ → cache, web の順、その後 100% db
+    assert services == ["cache", "web", "db"]
+
+
+def test_all_uptime_filters_by_q_substring_case_insensitive():
+    _post("web-api", "healthy", 10.0, 1.0)
+    _post("web-api", "unhealthy", 100.0, 2.0)
+    _post("db-primary", "healthy", 20.0, 1.0)
+    resp = client.get("/metrics/uptime?q=WEB")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "web-api"
+
+
+def test_all_uptime_filters_by_time_range():
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    _post("db", "healthy", 20.0, 10.0)
+    _post("db", "unhealthy", 800.0, 11.0)
+    # since=5 → web は窓外、db のみ集計対象
+    resp = client.get("/metrics/uptime?since=5")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "db"
+
+
+def test_all_uptime_ongoing_only_filter():
+    # web は incident 終了済み
+    _post("web", "unhealthy", 100.0, 2.0)
+    _post("web", "healthy", 11.0, 3.0)
+    # db は incident 進行中（末尾が unhealthy）
+    _post("db", "degraded", 800.0, 4.0)
+    _post("db", "unhealthy", 900.0, 5.0)
+    resp = client.get("/metrics/uptime?ongoing_only=true")
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["services"][0]["service"] == "db"
+    assert data["services"][0]["ongoing_incident"] is True
+
+
+def test_all_uptime_order_desc_reverses_list():
+    _post("web", "healthy", 10.0, 1.0)
+    _post("web", "healthy", 11.0, 2.0)
+    _post("db", "healthy", 20.0, 1.0)
+    _post("db", "unhealthy", 800.0, 2.0)
+    _post("db", "healthy", 22.0, 3.0)
+    resp = client.get("/metrics/uptime?order=desc")
+    data = resp.json()
+    assert data["order"] == "desc"
+    # asc は db (低 uptime) → web、desc 反転で web → db
+    services = [s["service"] for s in data["services"]]
+    assert services == ["web", "db"]
+
+
+def test_all_uptime_pagination_limit_and_offset():
+    _post("alpha", "healthy", 10.0, 1.0)
+    _post("alpha", "unhealthy", 100.0, 2.0)
+    _post("alpha", "healthy", 11.0, 3.0)
+    _post("beta", "healthy", 20.0, 1.0)
+    _post("gamma", "healthy", 30.0, 1.0)
+    # uptime: alpha=66.67%, beta=100%, gamma=100%
+    # asc 順: alpha (66.67), beta (100, タイブレーカで先), gamma (100)
+    resp = client.get("/metrics/uptime?limit=1&offset=1")
+    data = resp.json()
+    assert data["total"] == 3
+    assert data["count"] == 1
+    assert data["limit"] == 1
+    assert data["offset"] == 1
+    assert data["services"][0]["service"] == "beta"
+
+
+def test_all_uptime_excludes_services_with_no_records_in_window():
+    # web のレコードは since 範囲外、db は範囲内
+    _post("web", "healthy", 10.0, 1.0)
+    _post("db", "healthy", 20.0, 10.0)
+    resp = client.get("/metrics/uptime?since=5")
+    data = resp.json()
+    # web は集計対象外（範囲内 0 件）→ 結果に含まれない
+    services = [s["service"] for s in data["services"]]
+    assert services == ["db"]
+
+
+def test_all_uptime_rejects_invalid_range():
+    resp = client.get("/metrics/uptime?since=10&until=5")
+    assert resp.status_code == 400
+
+
+def test_all_uptime_rejects_blank_q():
+    resp = client.get("/metrics/uptime?q=%20%20")
+    assert resp.status_code == 400
+
+
+def test_all_uptime_rejects_zero_limit():
+    resp = client.get("/metrics/uptime?limit=0")
+    assert resp.status_code == 422
+
+
+def test_all_uptime_no_records_when_no_services_match_q():
+    _post("web", "healthy", 10.0, 1.0)
+    resp = client.get("/metrics/uptime?q=nonexistent")
+    data = resp.json()
+    assert data["total"] == 0
+    assert data["services"] == []
+
+
+def test_metrics_store_all_uptime_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=10.0, timestamp=1.0))
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=11.0, timestamp=2.0))
+    s.add(MetricRecord(service="db", status="healthy", response_time_ms=20.0, timestamp=1.0))
+    s.add(MetricRecord(service="db", status="unhealthy", response_time_ms=800.0, timestamp=2.0))
+    result = s.all_uptime()
+    assert len(result) == 2
+    # asc uptime_pct: db (50%) < web (100%)
+    assert result[0]["service"] == "db"
+    assert result[1]["service"] == "web"
+    assert result[1]["uptime_pct"] == 100.0
+    # uptime() と同じフィールドが揃っている
+    assert set(result[0].keys()) == {
+        "service", "total_checks", "healthy_checks", "uptime_pct",
+        "incident_count", "ongoing_incident", "total_incident_seconds",
+        "longest_incident_seconds", "mean_incident_seconds",
+    }


### PR DESCRIPTION
## 概要

- `MetricsStore.all_uptime(q, since, until)` を追加: `distinct_services()` でフィルタ通過後の service 名一覧を取り、各サービスに対し既存 `uptime()` を呼んで結果を集約する。範囲内にレコードが無いサービスは結果に含めない。
- `GET /metrics/uptime` ハンドラを追加: 全サービスの SLA 集約値（uptime_pct, incident_count, ongoing_incident, total/longest/mean_incident_seconds 等の 9 フィールド）を 1 リクエストで返す。
- 並びは `uptime_pct` 昇順をベースに service 名昇順をタイブレーカ（worst-uptime 先頭）。`order=desc` で反転。
- クエリ: `q` / `since` / `until` / `ongoing_only` / `limit` / `offset` / `order` を `/metrics/incidents` と同じ規約で実装。
- バリデーションは `since>until` `空白 q` `非有限数` を 400、`limit=0` 等は 422、レスポンス構造は `count` / `total` / `limit` / `offset` / `order` / `services` で他の cross-service エンドポイントと統一。

## テスト

`analytics-api/test_main.py` に 13 ケース追加:

- 空ストア → 空応答
- 各サービス集約 + 全 9 フィールド存在チェック
- `uptime_pct` 昇順 + service 名タイブレーカ
- `q` 部分一致フィルタ（大文字小文字無視）
- `since` / `until` 範囲フィルタ
- `ongoing_only` フィルタ（進行中インシデント保有サービスのみ）
- `order=desc` での反転
- `limit` / `offset` ページング
- ウィンドウ内にレコードが無いサービスの除外
- 不正範囲 (`since>until`) → 400
- 空白 `q` → 400
- `limit=0` → 422 (Pydantic Query 制約)
- `q` ヒット 0 件
- `MetricsStore.all_uptime()` の単体テスト

## 動作確認

```bash
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py
pytest -v
# => 300 passed
```

Closes #105