### PR TITLE
fix(api-gateway): 不正 JSON ボディに 500 ではなく 400 を返す

### DIFF
--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -914,4 +914,42 @@ describe("API Gateway", () => {
       spy.mockRestore();
     });
   });
+
+  describe("Malformed JSON body", () => {
+    it("returns 400 with JSON error on invalid JSON to POST /api/metrics", async () => {
+      const spy = jest.spyOn(axios, "post");
+      const res = await request(app)
+        .post("/api/metrics")
+        .set("Content-Type", "application/json")
+        .send("{not-valid-json");
+      expect(res.status).toBe(400);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(res.body.error).toBe("invalid JSON body");
+      // 上流 analytics-api には転送されない
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("returns 400 with JSON error on invalid JSON to POST /api/metrics/batch", async () => {
+      const spy = jest.spyOn(axios, "post");
+      const res = await request(app)
+        .post("/api/metrics/batch")
+        .set("Content-Type", "application/json")
+        .send('{"metrics":[');
+      expect(res.status).toBe(400);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(res.body.error).toBe("invalid JSON body");
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("returns 400 with JSON error on completely empty body with JSON content-type", async () => {
+      const res = await request(app)
+        .post("/api/metrics")
+        .set("Content-Type", "application/json")
+        .send("not json at all");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid JSON body");
+    });
+  });
 });

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -298,10 +298,15 @@ app.use((_req: Request, res: Response) => {
 // express.json の limit 超過は SyntaxError ではなく entity.too.large になる。
 // 既定の Express エラーハンドラに任せると HTML を返してしまうため、
 // JSON で 413 を返す専用ハンドラを 500 ハンドラの前段に置く。
+// 同様に、構文不正な JSON ボディは body-parser が SyntaxError
+// (`type === 'entity.parse.failed'`) を投げる。これを 500 ハンドラまで
+// 落とすと "Internal server error" として 5xx を返してしまい、
+// SRE の 5xx アラートが誤発火し原因（クライアント側の不正リクエスト）も
+// 分からない。413 と並列で 400 ハンドラを用意し、JSON で明示的に返す。
 app.use(
   (
     err: Error & { type?: string; status?: number; statusCode?: number },
-    _req: Request,
+    req: Request,
     res: Response,
     next: NextFunction,
   ) => {
@@ -309,6 +314,11 @@ app.use(
     if (err && (err.type === "entity.too.large" || status === 413)) {
       logger.warn("Request body too large", { limit: MAX_REQUEST_BODY });
       res.status(413).json({ error: "request body too large" });
+      return;
+    }
+    if (err instanceof SyntaxError && err.type === "entity.parse.failed") {
+      logger.warn("Malformed JSON body", { path: req.path });
+      res.status(400).json({ error: "invalid JSON body" });
       return;
     }
     next(err);


### PR DESCRIPTION
## 概要

- `express.json()` が投げる `SyntaxError` (`type === 'entity.parse.failed'`) を専用ハンドラで捕まえ、`{"error":"invalid JSON body"}` を 400 として JSON で返す
- これまで構文不正な JSON は最終段の 500 ハンドラに落ちて "Internal server error" を返していた → クライアント起因の不正リクエストで SRE の 5xx アラートが誤発火していた
- 既存の `entity.too.large`（413）ハンドラと並列に配置し、`req.path` を `logger.warn` でレコード（ペイロード本文はログに残さない）
- `POST /api/metrics` / `POST /api/metrics/batch` への malformed JSON テストを 3 ケース追加

## 対応 Issue

Closes #107

## 動作確認

- `cd api-gateway && npm run lint` — クリーン
- `cd api-gateway && npm test` — 67/67 パス（既存 64 + 新規 3）

---
_Generated by [Claude Code](https://claude.ai/code/session_017xZmYtDxDfBFCBv1BXDUrX)_