### PR TITLE
feat(health-checker): CheckService HTTP クライアントタイムアウトを CHECK_HTTP_TIMEOUT_SECONDS で環境変数化

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `METRIC_REPORT_MAX_ATTEMPTS` | `3` | Health Checker: analytics-api への POST `/metrics` 最大試行回数（`1` でリトライ無効） |
 | `METRIC_REPORT_BACKOFF_MS` | `100` | Health Checker: メトリクス報告の指数バックオフ初期値（ミリ秒） |
 | `CHECK_INTERVAL_SECONDS` | `0` | Health Checker: バックグラウンド定期チェックの間隔（秒、`0` で無効） |
+| `CHECK_HTTP_TIMEOUT_SECONDS` | `5` | Health Checker: 各サービス `/health` チェックおよび analytics-api への POST に使う HTTP クライアントのタイムアウト（秒）。高遅延ネットワーク環境では大きめに設定する。`0` や不正値の場合は既定値にフォールバック |
 
 ## Testing
 
@@ -474,8 +475,8 @@ pulseboard/
 ├── api-gateway/              # TypeScript API Gateway
 │   ├── src/
 │   │   ├── app.ts
-│   │   ├��─ app.test.ts
-���   │   └── index.ts
+│   │   ├── app.test.ts
+│   │   └── index.ts
 │   ├── package.json
 │   ├── tsconfig.json
 │   ├── jest.config.js
@@ -486,8 +487,8 @@ pulseboard/
 │   ├── test_main.py
 │   ├── requirements.txt
 │   └── Dockerfile
-├���─ health-checker/           # Go Health Checker
-│   ├���─ main.go
+├── health-checker/           # Go Health Checker
+│   ├── main.go
 │   ├── main_test.go
 │   ├── go.mod
 │   └── Dockerfile

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -133,6 +133,21 @@ func envMillis(key string, fallback time.Duration) time.Duration {
 	return fallback
 }
 
+// newCheckHTTPClient はサービス /health のチェック・analytics-api への
+// メトリクス送信に使う共通 HTTP クライアントを生成する。
+//
+// タイムアウトは CHECK_HTTP_TIMEOUT_SECONDS 環境変数で上書き可能。
+// 既定 5 秒。0 / 不正値の場合は envSeconds の挙動で既定値にフォールバック。
+//
+// 旧実装では makeCheckHandler と main の 2 箇所で
+// `&http.Client{Timeout: 5 * time.Second}` がハードコードされており、
+// 片方だけ変更されると drift する状態だった。本関数で 1 箇所に集約する。
+func newCheckHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: envSeconds("CHECK_HTTP_TIMEOUT_SECONDS", 5*time.Second),
+	}
+}
+
 // shouldRetryStatus は HTTP ステータスコードがリトライに値するかを返す。
 // 5xx は一時的障害として再試行し、429 (Too Many Requests) と 408 (Request
 // Timeout) も対象。それ以外の 4xx はクライアント不備なので即時失敗とする。
@@ -274,7 +289,7 @@ func makeCheckHandler(targets []ServiceTarget, analyticsURL string) http.Handler
 		if !methodAllowed(w, r, http.MethodGet, http.MethodPost) {
 			return
 		}
-		client := &http.Client{Timeout: 5 * time.Second}
+		client := newCheckHTTPClient()
 
 		results, reported := checkAndReportTargets(client, targets, analyticsURL)
 
@@ -355,7 +370,7 @@ func main() {
 	}()
 
 	if checkInterval > 0 {
-		periodicClient := &http.Client{Timeout: 5 * time.Second}
+		periodicClient := newCheckHTTPClient()
 		go runPeriodicChecks(ctx, periodicClient, targets, analyticsURL, checkInterval)
 	}
 

--- a/health-checker/main_test.go
+++ b/health-checker/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -756,5 +757,59 @@ func TestRunPeriodicChecks_ImmediateCancelReturns(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("runPeriodicChecks did not exit promptly when ctx already canceled")
+	}
+}
+
+// TestNewCheckHTTPClient_DefaultTimeout は CHECK_HTTP_TIMEOUT_SECONDS 未設定時に
+// 既定値の 5 秒が使われることを検証する。
+// 旧実装で 2 箇所にハードコードされていた値の置換であり、互換性のため既定は変えない。
+func TestNewCheckHTTPClient_DefaultTimeout(t *testing.T) {
+	t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", "") // 念のため未設定状態を明示
+
+	client := newCheckHTTPClient()
+
+	if client == nil {
+		t.Fatal("newCheckHTTPClient returned nil")
+	}
+	if got, want := client.Timeout, 5*time.Second; got != want {
+		t.Errorf("default Timeout = %v, want %v", got, want)
+	}
+}
+
+// TestNewCheckHTTPClient_RespectsEnvOverride は CHECK_HTTP_TIMEOUT_SECONDS で
+// 任意の秒数に上書きできることを検証する。
+// 高遅延環境（CI / 海外リージョン）で 5 秒を超える応答を許容するための導線。
+func TestNewCheckHTTPClient_RespectsEnvOverride(t *testing.T) {
+	t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", "10")
+
+	client := newCheckHTTPClient()
+
+	if got, want := client.Timeout, 10*time.Second; got != want {
+		t.Errorf("Timeout = %v, want %v", got, want)
+	}
+}
+
+// TestNewCheckHTTPClient_InvalidValueFallsBackToDefault は不正値・0・負値を
+// 設定しても既定 5 秒にフォールバックすることを検証する。
+// envSeconds の既存挙動（n > 0 のみ採用）に依存するため、ここでは複数の
+// 「不正な」入力を表で網羅する。
+func TestNewCheckHTTPClient_InvalidValueFallsBackToDefault(t *testing.T) {
+	cases := []string{
+		"",
+		"0",
+		"-1",
+		"abc",
+		"3.5", // strconv.Atoi では小数を弾く
+	}
+	for _, raw := range cases {
+		t.Run(fmt.Sprintf("value=%q", raw), func(t *testing.T) {
+			t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", raw)
+
+			client := newCheckHTTPClient()
+
+			if got, want := client.Timeout, 5*time.Second; got != want {
+				t.Errorf("Timeout = %v, want %v (fallback)", got, want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 変更概要

`health-checker/main.go` の 2 箇所 (`makeCheckHandler` / `main`) にハードコードされていた `&http.Client{Timeout: 5 * time.Second}` を、新規ヘルパー `newCheckHTTPClient()` で集約し、`CHECK_HTTP_TIMEOUT_SECONDS` 環境変数で上書き可能にする。

### 変更内容

- **`health-checker/main.go`**
  - `newCheckHTTPClient()` ヘルパー関数を追加。`envSeconds("CHECK_HTTP_TIMEOUT_SECONDS", 5*time.Second)` をタイムアウトとした `*http.Client` を返す
  - `makeCheckHandler` 内のハードコードを `newCheckHTTPClient()` 呼び出しに差し替え
  - `main` 内の `periodicClient` も `newCheckHTTPClient()` に差し替え
  - 既定値 5 秒は維持（後方互換）

- **`health-checker/main_test.go`** （テスト 3 件追加）
  - `TestNewCheckHTTPClient_DefaultTimeout`：未設定で 5 秒
  - `TestNewCheckHTTPClient_RespectsEnvOverride`：`CHECK_HTTP_TIMEOUT_SECONDS=10` で 10 秒
  - `TestNewCheckHTTPClient_InvalidValueFallsBackToDefault`：`""` / `"0"` / `"-1"` / `"abc"` / `"3.5"` の各不正値で 5 秒へフォールバック（テーブル駆動 5 サブテスト）

- **`README.md`**
  - 環境変数表に `CHECK_HTTP_TIMEOUT_SECONDS` 行を追記

### 対応 Issue

Closes #115

## 動作確認

ローカルで以下を実行し、全てパスを確認済み：

```bash
cd health-checker
go vet ./...          # クリーン
go test -count=1 ./...
# === RUN   TestNewCheckHTTPClient_DefaultTimeout
# --- PASS
# === RUN   TestNewCheckHTTPClient_RespectsEnvOverride
# --- PASS
# === RUN   TestNewCheckHTTPClient_InvalidValueFallsBackToDefault
#     --- PASS: value=""
#     --- PASS: value="0"
#     --- PASS: value="-1"
#     --- PASS: value="abc"
#     --- PASS: value="3.5"
# PASS
```

既存テスト（`TestCheckHandler*` / `TestReportMetric_*` / `TestRunPeriodicChecks_*` 等）も引き続き全てパス。

## 影響範囲

- `health-checker/main.go` — `newCheckHTTPClient` 追加 + 既存 2 箇所のクライアント生成を置換
- `health-checker/main_test.go` — テスト 3 件追加 (`fmt` import 追加)
- `README.md` — 環境変数表に 1 行追記

実装側の挙動はデフォルト値 5 秒で完全に後方互換。`CHECK_HTTP_TIMEOUT_SECONDS` を明示的に設定したときのみ挙動が変わる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmtWCQKFeLdcNNg15qcKFB)_