### PR TITLE
feat(health-checker): EXTRA_TARGETS で追加監視対象を指定可能に

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ LOG_LEVEL=INFO
 # CHECK_INTERVAL_SECONDS=0  # >0 でバックグラウンド定期チェックを有効化（0 / 未設定で無効）
 # METRIC_REPORT_MAX_ATTEMPTS=3
 # METRIC_REPORT_BACKOFF_MS=100
+# 追加監視対象を JSON 配列で指定（デフォルトの analytics-api / api-gateway に append される）
+# パース失敗時は警告ログを出してデフォルトのみで起動する（fail-open）
+# EXTRA_TARGETS=[{"name":"redis","url":"http://redis:6379/ping"},{"name":"mailer","url":"http://mailer:9000/healthz"}]

--- a/README.md
+++ b/README.md
@@ -425,6 +425,22 @@ analytics-api の一時的な障害（接続エラー、5xx、429 Too Many Reque
 - 初期バックオフは `METRIC_REPORT_BACKOFF_MS`（既定 `100`）。`backoff × 2^(n-1)` で増加
 - 4xx（429 を除く）はリクエスト不備なので即時失敗とする
 
+**追加監視対象 (Extra targets):**
+
+デフォルトでは `analytics-api` と `api-gateway` のみを監視するが、
+`EXTRA_TARGETS` 環境変数に JSON 配列を渡すことで追加ターゲットを末尾に append できる。
+サイドカーやサードパーティ製サービス（Redis / メール送信 / 外部 API 等）を
+再ビルド無しで監視対象に加えるための拡張ポイント。
+
+```bash
+EXTRA_TARGETS='[{"name":"redis","url":"http://redis:6379/ping"},{"name":"mailer","url":"http://mailer:9000/healthz"}]'
+```
+
+- `name` / `url` の両方が非空のエントリのみ有効。片方でも空だと該当エントリはスキップされる
+- JSON パース失敗時は警告ログを出してデフォルトターゲットのみで起動（fail-open）
+  — オペレータの typo でコンテナが再起動ループに陥らないようにするための設計
+- 追加ターゲットにも同じ間隔・タイムアウト・リトライ設定が適用される
+
 ## Configuration
 
 All services are configured via environment variables. See [`.env.example`](.env.example) for the full list.
@@ -449,6 +465,7 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `METRIC_REPORT_BACKOFF_MS` | `100` | Health Checker: メトリクス報告の指数バックオフ初期値（ミリ秒） |
 | `CHECK_INTERVAL_SECONDS` | `0` | Health Checker: バックグラウンド定期チェックの間隔（秒、`0` で無効） |
 | `CHECK_HTTP_TIMEOUT_SECONDS` | `5` | Health Checker: 各サービス `/health` チェックおよび analytics-api への POST に使う HTTP クライアントのタイムアウト（秒）。高遅延ネットワーク環境では大きめに設定する。`0` や不正値の場合は既定値にフォールバック |
+| `EXTRA_TARGETS` | （未設定） | Health Checker: デフォルトターゲットに加えて監視する追加サービスの JSON 配列。例: `[{"name":"redis","url":"http://redis:6379/ping"}]`。パース失敗時は警告ログを出してデフォルトのみで起動する |
 
 ## Testing
 

--- a/health-checker/extra_targets_test.go
+++ b/health-checker/extra_targets_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"testing"
+)
+
+// parseExtraTargets の境界条件テスト。
+//
+// EXTRA_TARGETS 環境変数は運用時にオペレータが手書きで注入するため、
+// パース失敗（不正 JSON・型不一致）・空エントリ（name/url 抜け）に対して
+// fail-open で挙動を明示的に保証する。
+func TestParseExtraTargets(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    []ServiceTarget
+		wantErr bool
+	}{
+		{
+			name: "empty string returns nil without error",
+			raw:  "",
+			want: nil,
+		},
+		{
+			name: "empty JSON array returns empty slice",
+			raw:  "[]",
+			want: []ServiceTarget{},
+		},
+		{
+			name: "single valid entry",
+			raw:  `[{"name":"redis","url":"http://redis:6379/ping"}]`,
+			want: []ServiceTarget{{Name: "redis", URL: "http://redis:6379/ping"}},
+		},
+		{
+			name: "multiple valid entries preserve order",
+			raw:  `[{"name":"a","url":"http://a"},{"name":"b","url":"http://b"},{"name":"c","url":"http://c"}]`,
+			want: []ServiceTarget{
+				{Name: "a", URL: "http://a"},
+				{Name: "b", URL: "http://b"},
+				{Name: "c", URL: "http://c"},
+			},
+		},
+		{
+			name: "entry missing name is skipped",
+			raw:  `[{"name":"","url":"http://x"},{"name":"y","url":"http://y"}]`,
+			want: []ServiceTarget{{Name: "y", URL: "http://y"}},
+		},
+		{
+			name: "entry missing url is skipped",
+			raw:  `[{"name":"x","url":""},{"name":"y","url":"http://y"}]`,
+			want: []ServiceTarget{{Name: "y", URL: "http://y"}},
+		},
+		{
+			name: "all entries missing required fields returns empty",
+			raw:  `[{"name":"","url":""},{"name":"only-name"}]`,
+			want: []ServiceTarget{},
+		},
+		{
+			name:    "invalid JSON returns error",
+			raw:     `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "JSON object instead of array returns error",
+			raw:     `{"name":"x","url":"http://x"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseExtraTargets(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d entries, want %d: got=%+v", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i].Name != tc.want[i].Name || got[i].URL != tc.want[i].URL {
+					t.Errorf("entry[%d]: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// NewTargets が EXTRA_TARGETS 環境変数から追加ターゲットを取り込むことを検証する。
+// デフォルトの 2 ターゲット (analytics-api, api-gateway) の後ろに append されること、
+// パース失敗時はデフォルトターゲットのみで返ることを保証する。
+func TestNewTargets_AppendsExtraTargetsFromEnv(t *testing.T) {
+	t.Setenv("ANALYTICS_URL", "http://analytics")
+	t.Setenv("GATEWAY_URL", "http://gateway")
+	t.Setenv("EXTRA_TARGETS", `[{"name":"mailer","url":"http://mailer/healthz"},{"name":"redis","url":"http://redis:6379/ping"}]`)
+
+	targets := NewTargets()
+
+	if got, want := len(targets), 4; got != want {
+		t.Fatalf("len(targets) = %d, want %d: %+v", got, want, targets)
+	}
+	if targets[0].Name != "analytics-api" {
+		t.Errorf("targets[0].Name = %q, want analytics-api", targets[0].Name)
+	}
+	if targets[1].Name != "api-gateway" {
+		t.Errorf("targets[1].Name = %q, want api-gateway", targets[1].Name)
+	}
+	if targets[2].Name != "mailer" || targets[2].URL != "http://mailer/healthz" {
+		t.Errorf("targets[2] = %+v, want {mailer http://mailer/healthz}", targets[2])
+	}
+	if targets[3].Name != "redis" || targets[3].URL != "http://redis:6379/ping" {
+		t.Errorf("targets[3] = %+v, want {redis http://redis:6379/ping}", targets[3])
+	}
+}
+
+func TestNewTargets_InvalidExtraTargetsFallsBackToDefaults(t *testing.T) {
+	t.Setenv("ANALYTICS_URL", "http://analytics")
+	t.Setenv("GATEWAY_URL", "http://gateway")
+	t.Setenv("EXTRA_TARGETS", `this is not json`)
+
+	targets := NewTargets()
+
+	if got, want := len(targets), 2; got != want {
+		t.Fatalf("len(targets) = %d, want %d: %+v", got, want, targets)
+	}
+}
+
+func TestNewTargets_EmptyExtraTargetsReturnsDefaults(t *testing.T) {
+	t.Setenv("ANALYTICS_URL", "http://analytics")
+	t.Setenv("GATEWAY_URL", "http://gateway")
+	t.Setenv("EXTRA_TARGETS", "")
+
+	targets := NewTargets()
+
+	if got, want := len(targets), 2; got != want {
+		t.Fatalf("len(targets) = %d, want %d: %+v", got, want, targets)
+	}
+}

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -241,13 +241,48 @@ func reportMetricWithPolicy(
 	return lastErr
 }
 
+// parseExtraTargets は EXTRA_TARGETS 環境変数の値をパースし、追加ターゲットを返す。
+//
+// 期待する形式は JSON 配列で、各要素は `{"name":"","url":""}`。空文字列・
+// パース失敗・型ミスマッチ・name/url いずれかが空のエントリは無視し、
+// プロセスは常にデフォルトターゲットのみで起動できるように fail-open にする
+// （運用時に誤った JSON を渡してもコンテナが再起動ループしない）。
+//
+// 復帰値の第 2 引数はパースに失敗した場合のエラー。呼び元は警告ログのみに使い、
+// 起動可否の判定には使わない（設定ミス通知の観点で有用だが致命傷ではない）。
+func parseExtraTargets(raw string) ([]ServiceTarget, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var entries []ServiceTarget
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return nil, err
+	}
+	valid := make([]ServiceTarget, 0, len(entries))
+	for _, e := range entries {
+		if e.Name == "" || e.URL == "" {
+			continue
+		}
+		valid = append(valid, e)
+	}
+	return valid, nil
+}
+
 func NewTargets() []ServiceTarget {
 	analyticsURL := GetEnv("ANALYTICS_URL", "http://localhost:8001")
 	gatewayURL := GetEnv("GATEWAY_URL", "http://localhost:8000")
-	return []ServiceTarget{
+	targets := []ServiceTarget{
 		{Name: "analytics-api", URL: analyticsURL + "/health"},
 		{Name: "api-gateway", URL: gatewayURL + "/health"},
 	}
+	// EXTRA_TARGETS で追加ターゲットを末尾に append する。
+	// パース失敗時は警告ログのみ出してデフォルトターゲットで起動を続行する。
+	if extras, err := parseExtraTargets(os.Getenv("EXTRA_TARGETS")); err != nil {
+		log.Printf("[WARN] Ignoring EXTRA_TARGETS due to parse error: %v", err)
+	} else if len(extras) > 0 {
+		targets = append(targets, extras...)
+	}
+	return targets
 }
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 変更概要

- `health-checker/main.go`
  - `parseExtraTargets(raw string) ([]ServiceTarget, error)` を新規追加。JSON 配列をパースし、`name` / `url` の両方が非空のエントリのみ返す
  - `NewTargets()` を拡張し、`EXTRA_TARGETS` 環境変数の値を parse して既存デフォルト 2 ターゲット (analytics-api / api-gateway) の後ろに append
  - パース失敗時は警告ログを出してデフォルトターゲットで起動を継続 (fail-open)。オペレータの typo でコンテナが再起動ループに陥らないための設計
- `health-checker/extra_targets_test.go` を新規追加
  - `parseExtraTargets` の境界条件（空文字 / 空配列 / 単一・複数エントリ / name-only / url-only / 不正 JSON / オブジェクト形式）を 9 ケース網羅
  - `NewTargets` の統合テスト 3 本 (append 動作 / パース失敗フォールバック / 空文字列)
- `README.md` — 「追加監視対象 (Extra targets)」セクションと設定変数表に `EXTRA_TARGETS` の説明・サンプル・fail-open 挙動を追加
- `.env.example` — `EXTRA_TARGETS` のコメントアウトサンプル値を追加

## 対応 Issue

Closes #121

## 動作確認

ローカル環境で CI と同等のコマンドを全てパスすることを確認:

```
go vet ./...        # ✅ pass
go build ./...      # ✅ pass
go test ./...       # ✅ 全 46 テスト pass (34 既存 + 12 新規)
```

## 後方互換性

- `EXTRA_TARGETS` 未設定時はデフォルトターゲット 2 件のみで起動 (現行動作と完全に一致)
- 追加ターゲットにも既存の `CHECK_INTERVAL_SECONDS` / `CHECK_HTTP_TIMEOUT_SECONDS` / `METRIC_REPORT_*` が同じく適用される

---
_Generated by [Claude Code](https://claude.ai/code/session_015NSMFbinWNJW9BwztgU2GJ)_