### PR TITLE
feat(health-checker): 実行中の設定値を返す /config エンドポイントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,32 @@ curl "http://localhost:8001/metrics/services/web/timeseries?bucket_seconds=300&s
 |--------|----------|-------------|
 | GET | `/health` | Health check |
 | GET | `/check` | Run health checks on all configured targets |
+| GET | `/config` | 実行中の設定値（間隔・タイムアウト・リトライ・analytics-api URL）を JSON で返す |
+
+**実行時設定の確認 (`GET /config`):**
+
+環境変数由来のパラメータがプロセスに正しく反映されているかをコンテナ外から確認できる。
+`CHECK_INTERVAL_SECONDS=60` のつもりが typo で `CHECK_INTERAVAL_SECONDS` になっていたケースなど、
+JSON レスポンス側の該当キー（例: `check_interval_seconds`）を見れば即座に気付ける。
+値はプロセス起動時に一度だけ環境変数から構築され、以降は不変。
+
+レスポンス例:
+```json
+{
+  "analytics_url": "http://analytics-api:8001",
+  "check_interval_seconds": 30,
+  "check_http_timeout_seconds": 5,
+  "metric_report_max_attempts": 3,
+  "metric_report_backoff_ms": 100,
+  "server": {
+    "read_header_timeout_seconds": 5,
+    "read_timeout_seconds": 15,
+    "write_timeout_seconds": 15,
+    "idle_timeout_seconds": 60
+  },
+  "shutdown_timeout_seconds": 30
+}
+```
 
 **バックグラウンド定期チェック (Periodic checks):**
 

--- a/health-checker/config_handler_test.go
+++ b/health-checker/config_handler_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// GET /config が起動時に構築した RuntimeConfig を JSON で返すことを確認する。
+// 検証点:
+//   - HTTP 200
+//   - Content-Type: application/json
+//   - 各キーが期待値と一致
+func TestConfigHandlerReturnsRuntimeConfig(t *testing.T) {
+	config := RuntimeConfig{
+		AnalyticsURL:            "http://analytics.example:8001",
+		CheckIntervalSeconds:    30,
+		CheckHTTPTimeoutSeconds: 5,
+		MetricReportMaxAttempts: 3,
+		MetricReportBackoffMs:   100,
+		Server: ServerConfig{
+			ReadHeaderTimeoutSeconds: 5,
+			ReadTimeoutSeconds:       15,
+			WriteTimeoutSeconds:      15,
+			IdleTimeoutSeconds:       60,
+		},
+		ShutdownTimeoutSeconds: 30,
+	}
+	handler := makeConfigHandler(config)
+
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("content-type: got %q, want application/json prefix", ct)
+	}
+
+	var body RuntimeConfig
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body != config {
+		t.Errorf("body: got %+v, want %+v", body, config)
+	}
+}
+
+// HEAD /config も 200 で応答し、既存 /targets と同じメソッド許可規約を満たすこと。
+func TestConfigHandlerAllowsHeadMethod(t *testing.T) {
+	handler := makeConfigHandler(RuntimeConfig{})
+	req := httptest.NewRequest(http.MethodHead, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+}
+
+// GET / HEAD 以外のメソッドは 405 を返し、Allow ヘッダを付与すること。
+func TestConfigHandlerRejectsUnsupportedMethods(t *testing.T) {
+	handler := makeConfigHandler(RuntimeConfig{})
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		req := httptest.NewRequest(method, "/config", nil)
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("method=%s status: got %d, want 405", method, rec.Code)
+		}
+		if allow := rec.Header().Get("Allow"); !strings.Contains(allow, http.MethodGet) {
+			t.Errorf("method=%s Allow header: got %q, want to contain GET", method, allow)
+		}
+		if allow := rec.Header().Get("Allow"); !strings.Contains(allow, http.MethodHead) {
+			t.Errorf("method=%s Allow header: got %q, want to contain HEAD", method, allow)
+		}
+	}
+}
+
+// loadRuntimeConfig() は env 未設定時にドキュメントされているデフォルト値を返すこと。
+// 各デフォルト値は main() 内の env 読み取り箇所と同一である必要がある（drift 防止）。
+func TestLoadRuntimeConfigDefaultsMatchMain(t *testing.T) {
+	// env は Setenv せず既定値のみで検査する。
+	// Go test は各テストで env を隔離しないので、CI に依存しないよう
+	// 各キーを明示的にクリアする。
+	t.Setenv("ANALYTICS_URL", "")
+	t.Setenv("CHECK_INTERVAL_SECONDS", "")
+	t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", "")
+	t.Setenv("METRIC_REPORT_MAX_ATTEMPTS", "")
+	t.Setenv("METRIC_REPORT_BACKOFF_MS", "")
+	t.Setenv("CHECKER_READ_HEADER_TIMEOUT", "")
+	t.Setenv("CHECKER_READ_TIMEOUT", "")
+	t.Setenv("CHECKER_WRITE_TIMEOUT", "")
+	t.Setenv("CHECKER_IDLE_TIMEOUT", "")
+	t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "")
+
+	cfg := loadRuntimeConfig()
+
+	if cfg.AnalyticsURL != "http://localhost:8001" {
+		t.Errorf("AnalyticsURL default: got %q, want http://localhost:8001", cfg.AnalyticsURL)
+	}
+	if cfg.CheckIntervalSeconds != 0 {
+		t.Errorf("CheckIntervalSeconds default: got %d, want 0", cfg.CheckIntervalSeconds)
+	}
+	if cfg.CheckHTTPTimeoutSeconds != 5 {
+		t.Errorf("CheckHTTPTimeoutSeconds default: got %d, want 5", cfg.CheckHTTPTimeoutSeconds)
+	}
+	if cfg.MetricReportMaxAttempts != 3 {
+		t.Errorf("MetricReportMaxAttempts default: got %d, want 3", cfg.MetricReportMaxAttempts)
+	}
+	if cfg.MetricReportBackoffMs != 100 {
+		t.Errorf("MetricReportBackoffMs default: got %d, want 100", cfg.MetricReportBackoffMs)
+	}
+	if cfg.Server.ReadHeaderTimeoutSeconds != 5 {
+		t.Errorf("ReadHeaderTimeout default: got %d, want 5", cfg.Server.ReadHeaderTimeoutSeconds)
+	}
+	if cfg.Server.ReadTimeoutSeconds != 15 {
+		t.Errorf("ReadTimeout default: got %d, want 15", cfg.Server.ReadTimeoutSeconds)
+	}
+	if cfg.Server.WriteTimeoutSeconds != 15 {
+		t.Errorf("WriteTimeout default: got %d, want 15", cfg.Server.WriteTimeoutSeconds)
+	}
+	if cfg.Server.IdleTimeoutSeconds != 60 {
+		t.Errorf("IdleTimeout default: got %d, want 60", cfg.Server.IdleTimeoutSeconds)
+	}
+	if cfg.ShutdownTimeoutSeconds != 30 {
+		t.Errorf("ShutdownTimeout default: got %d, want 30", cfg.ShutdownTimeoutSeconds)
+	}
+}
+
+// env で上書きされた値が RuntimeConfig に反映されること。
+// 「本当に env が効いたか」を確認するのが本エンドポイントの目的なので、
+// 主要 env の反映を統合的にテストする。
+func TestLoadRuntimeConfigReflectsEnvOverrides(t *testing.T) {
+	t.Setenv("ANALYTICS_URL", "http://analytics.example:9001")
+	t.Setenv("CHECK_INTERVAL_SECONDS", "45")
+	t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", "10")
+	t.Setenv("METRIC_REPORT_MAX_ATTEMPTS", "5")
+	t.Setenv("METRIC_REPORT_BACKOFF_MS", "250")
+	t.Setenv("CHECKER_READ_HEADER_TIMEOUT", "3")
+	t.Setenv("CHECKER_READ_TIMEOUT", "20")
+	t.Setenv("CHECKER_WRITE_TIMEOUT", "25")
+	t.Setenv("CHECKER_IDLE_TIMEOUT", "90")
+	t.Setenv("SHUTDOWN_TIMEOUT_SECONDS", "12")
+
+	cfg := loadRuntimeConfig()
+
+	if cfg.AnalyticsURL != "http://analytics.example:9001" {
+		t.Errorf("AnalyticsURL: got %q", cfg.AnalyticsURL)
+	}
+	if cfg.CheckIntervalSeconds != 45 {
+		t.Errorf("CheckIntervalSeconds: got %d, want 45", cfg.CheckIntervalSeconds)
+	}
+	if cfg.CheckHTTPTimeoutSeconds != 10 {
+		t.Errorf("CheckHTTPTimeoutSeconds: got %d, want 10", cfg.CheckHTTPTimeoutSeconds)
+	}
+	if cfg.MetricReportMaxAttempts != 5 {
+		t.Errorf("MetricReportMaxAttempts: got %d, want 5", cfg.MetricReportMaxAttempts)
+	}
+	if cfg.MetricReportBackoffMs != 250 {
+		t.Errorf("MetricReportBackoffMs: got %d, want 250", cfg.MetricReportBackoffMs)
+	}
+	if cfg.Server.ReadHeaderTimeoutSeconds != 3 {
+		t.Errorf("ReadHeaderTimeout: got %d, want 3", cfg.Server.ReadHeaderTimeoutSeconds)
+	}
+	if cfg.Server.ReadTimeoutSeconds != 20 {
+		t.Errorf("ReadTimeout: got %d, want 20", cfg.Server.ReadTimeoutSeconds)
+	}
+	if cfg.Server.WriteTimeoutSeconds != 25 {
+		t.Errorf("WriteTimeout: got %d, want 25", cfg.Server.WriteTimeoutSeconds)
+	}
+	if cfg.Server.IdleTimeoutSeconds != 90 {
+		t.Errorf("IdleTimeout: got %d, want 90", cfg.Server.IdleTimeoutSeconds)
+	}
+	if cfg.ShutdownTimeoutSeconds != 12 {
+		t.Errorf("ShutdownTimeout: got %d, want 12", cfg.ShutdownTimeoutSeconds)
+	}
+}
+
+// 不正値（負値・非数値）は既存 envSeconds / envIntAtLeastOne のフォールバック挙動により
+// デフォルト値へ戻ること。運用時に typo で "3s" のような値を渡してもクラッシュせず、
+// デフォルトの安全側パラメータで起動する fail-open が維持されていることを回帰する。
+func TestLoadRuntimeConfigFallsBackOnInvalidValues(t *testing.T) {
+	t.Setenv("CHECK_HTTP_TIMEOUT_SECONDS", "not-a-number")
+	t.Setenv("METRIC_REPORT_BACKOFF_MS", "-50")
+	t.Setenv("METRIC_REPORT_MAX_ATTEMPTS", "0") // envIntAtLeastOne は >=1 のみ受け入れる
+	t.Setenv("CHECKER_READ_TIMEOUT", "abc")
+
+	cfg := loadRuntimeConfig()
+
+	if cfg.CheckHTTPTimeoutSeconds != 5 {
+		t.Errorf("CheckHTTPTimeoutSeconds should fall back to 5 on invalid input, got %d", cfg.CheckHTTPTimeoutSeconds)
+	}
+	if cfg.MetricReportBackoffMs != 100 {
+		t.Errorf("MetricReportBackoffMs should fall back to 100 on negative input, got %d", cfg.MetricReportBackoffMs)
+	}
+	if cfg.MetricReportMaxAttempts != 3 {
+		t.Errorf("MetricReportMaxAttempts should fall back to 3 on <1 input, got %d", cfg.MetricReportMaxAttempts)
+	}
+	if cfg.Server.ReadTimeoutSeconds != 15 {
+		t.Errorf("ReadTimeoutSeconds should fall back to 15 on invalid input, got %d", cfg.Server.ReadTimeoutSeconds)
+	}
+}
+
+// makeConfigHandler は起動時にクロージャで固定した config を返し、
+// 後から env を変更しても反映されないこと（ハンドラは不変を維持）。
+// 運用中に env を書き換えても reload しない限り挙動は変わらないという設計を回帰する。
+func TestConfigHandlerIsClosureOverConstructedConfig(t *testing.T) {
+	original := RuntimeConfig{
+		AnalyticsURL:            "http://original.example:8001",
+		CheckIntervalSeconds:    30,
+		CheckHTTPTimeoutSeconds: 5,
+	}
+	handler := makeConfigHandler(original)
+
+	// env を書き換えても、既に構築済みのハンドラは影響を受けないはず。
+	t.Setenv("ANALYTICS_URL", "http://mutated.example:9001")
+	t.Setenv("CHECK_INTERVAL_SECONDS", "999")
+
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	var body RuntimeConfig
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.AnalyticsURL != "http://original.example:8001" {
+		t.Errorf("handler should return the config captured at construction, got %q", body.AnalyticsURL)
+	}
+	if body.CheckIntervalSeconds != 30 {
+		t.Errorf("handler should return the config captured at construction, got %d", body.CheckIntervalSeconds)
+	}
+}
+
+// JSON レスポンスに `server` ネストが存在し、各キーがドキュメント通りの名前で
+// 出力されること（tag drift を検知）。
+func TestConfigHandlerJSONShapeIncludesServerNesting(t *testing.T) {
+	config := RuntimeConfig{
+		Server: ServerConfig{
+			ReadHeaderTimeoutSeconds: 5,
+			ReadTimeoutSeconds:       15,
+			WriteTimeoutSeconds:      15,
+			IdleTimeoutSeconds:       60,
+		},
+	}
+	handler := makeConfigHandler(config)
+
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	// 生 JSON にキー名が現れることを確認する。
+	body := rec.Body.String()
+	for _, key := range []string{
+		"\"server\"",
+		"\"read_header_timeout_seconds\"",
+		"\"read_timeout_seconds\"",
+		"\"write_timeout_seconds\"",
+		"\"idle_timeout_seconds\"",
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("expected JSON to contain key %s, got: %s", key, body)
+		}
+	}
+}
+
+// トップレベルの JSON キー名が snake_case で、tag drift が無いこと。
+func TestConfigHandlerJSONShapeUsesSnakeCase(t *testing.T) {
+	handler := makeConfigHandler(RuntimeConfig{})
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	body := rec.Body.String()
+	expectedKeys := []string{
+		"\"analytics_url\"",
+		"\"check_interval_seconds\"",
+		"\"check_http_timeout_seconds\"",
+		"\"metric_report_max_attempts\"",
+		"\"metric_report_backoff_ms\"",
+		"\"shutdown_timeout_seconds\"",
+	}
+	for _, key := range expectedKeys {
+		if !strings.Contains(body, key) {
+			t.Errorf("expected JSON to contain snake_case key %s, got: %s", key, body)
+		}
+	}
+	// camelCase / PascalCase を誤って出力していないこと
+	unexpectedKeys := []string{
+		"\"analyticsUrl\"",
+		"\"AnalyticsURL\"",
+		"\"checkIntervalSeconds\"",
+		"\"CheckIntervalSeconds\"",
+	}
+	for _, key := range unexpectedKeys {
+		if strings.Contains(body, key) {
+			t.Errorf("unexpected non-snake_case key %s in JSON: %s", key, body)
+		}
+	}
+}
+
+// レスポンスに秘匿情報が含まれないことを回帰する（安全側の警戒）。
+// 現状は ANALYTICS_URL 等の非秘匿情報のみだが、将来 secret を扱う env を
+// 誤って RuntimeConfig に含めた場合の検知として、代表的な secret 由来のキー名や
+// 値が漏出していないことを確認する。
+func TestConfigHandlerDoesNotLeakSecrets(t *testing.T) {
+	handler := makeConfigHandler(RuntimeConfig{
+		AnalyticsURL: "http://analytics.example:8001",
+	})
+	req := httptest.NewRequest(http.MethodGet, "/config", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	body := strings.ToLower(rec.Body.String())
+	forbidden := []string{"password", "token", "secret", "api_key", "apikey"}
+	for _, needle := range forbidden {
+		if strings.Contains(body, needle) {
+			t.Errorf("config response should not contain %q (likely secret leak): %s", needle, rec.Body.String())
+		}
+	}
+}

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -347,6 +347,68 @@ func checkAndReportTargets(client *http.Client, targets []ServiceTarget, analyti
 	return results, int(reported)
 }
 
+// RuntimeConfig は health-checker の実行時設定を表す。
+// 環境変数由来の値をプロセス起動時に一度だけ読み取り、以降は不変で参照する。
+// `/config` エンドポイントはこの構造体をそのまま JSON エンコードして返す。
+type RuntimeConfig struct {
+	AnalyticsURL            string       `json:"analytics_url"`
+	CheckIntervalSeconds    int          `json:"check_interval_seconds"`
+	CheckHTTPTimeoutSeconds int          `json:"check_http_timeout_seconds"`
+	MetricReportMaxAttempts int          `json:"metric_report_max_attempts"`
+	MetricReportBackoffMs   int          `json:"metric_report_backoff_ms"`
+	Server                  ServerConfig `json:"server"`
+	ShutdownTimeoutSeconds  int          `json:"shutdown_timeout_seconds"`
+}
+
+// ServerConfig は net/http.Server 側のタイムアウト設定をまとめる。
+// `/config` レスポンスで "server" ネストとして出す。
+type ServerConfig struct {
+	ReadHeaderTimeoutSeconds int `json:"read_header_timeout_seconds"`
+	ReadTimeoutSeconds       int `json:"read_timeout_seconds"`
+	WriteTimeoutSeconds      int `json:"write_timeout_seconds"`
+	IdleTimeoutSeconds       int `json:"idle_timeout_seconds"`
+}
+
+// loadRuntimeConfig は環境変数から実行時設定を構築する。
+// main() の env 読み取り箇所と同じデフォルト値・単位換算ロジックを使い、
+// `/config` の返り値と実際の挙動が drift しないようにする。
+func loadRuntimeConfig() RuntimeConfig {
+	policy := loadRetryPolicy()
+	return RuntimeConfig{
+		AnalyticsURL:            GetEnv("ANALYTICS_URL", "http://localhost:8001"),
+		CheckIntervalSeconds:    int(envSeconds("CHECK_INTERVAL_SECONDS", 0) / time.Second),
+		CheckHTTPTimeoutSeconds: int(envSeconds("CHECK_HTTP_TIMEOUT_SECONDS", 5*time.Second) / time.Second),
+		MetricReportMaxAttempts: policy.maxAttempts,
+		MetricReportBackoffMs:   int(policy.backoff / time.Millisecond),
+		Server: ServerConfig{
+			ReadHeaderTimeoutSeconds: int(envSeconds("CHECKER_READ_HEADER_TIMEOUT", 5*time.Second) / time.Second),
+			ReadTimeoutSeconds:       int(envSeconds("CHECKER_READ_TIMEOUT", 15*time.Second) / time.Second),
+			WriteTimeoutSeconds:      int(envSeconds("CHECKER_WRITE_TIMEOUT", 15*time.Second) / time.Second),
+			IdleTimeoutSeconds:       int(envSeconds("CHECKER_IDLE_TIMEOUT", 60*time.Second) / time.Second),
+		},
+		ShutdownTimeoutSeconds: int(envSeconds("SHUTDOWN_TIMEOUT_SECONDS", 30*time.Second) / time.Second),
+	}
+}
+
+// makeConfigHandler は実行時設定を JSON で返すハンドラを生成する。
+//
+// 運用中に「本当に env が反映されたか」を curl 一発で確認できるようにする。
+// 例えば `CHECK_INTERVAL_SECONDS=60` のつもりが `CHECK_INTERAVAL_SECONDS`
+// と typo していた場合、`/config` を叩けば `check_interval_seconds: 0`
+// と表示され即座に気付ける。
+//
+// config はプロセス起動時に一度だけ構築されて以降は不変なので、
+// ハンドラ側でロックは不要。/targets / /health と同じく GET / HEAD のみ許可。
+func makeConfigHandler(config RuntimeConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !methodAllowed(w, r, http.MethodGet, http.MethodHead) {
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(config)
+	}
+}
+
 func makeCheckHandler(targets []ServiceTarget, analyticsURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !methodAllowed(w, r, http.MethodGet, http.MethodPost) {
@@ -406,6 +468,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", healthHandler)
 	mux.HandleFunc("/targets", makeTargetsHandler(targets))
+	mux.HandleFunc("/config", makeConfigHandler(loadRuntimeConfig()))
 	analyticsURL := GetEnv("ANALYTICS_URL", "http://localhost:8001")
 	mux.HandleFunc("/check", makeCheckHandler(targets, analyticsURL))
 


### PR DESCRIPTION
## 変更概要

- `health-checker` に `GET /config` エンドポイントを新設。実行時設定（間隔・タイムアウト・リトライ・analytics-api URL）を JSON で返す
- `RuntimeConfig` / `ServerConfig` 構造体、`loadRuntimeConfig()`、`makeConfigHandler()` を追加
- 既存 `/targets` と同じ methodAllowed 規約（GET / HEAD 200、それ以外 405 + Allow ヘッダ）
- 起動時にクロージャで固定した config を返すため、稼働中の env 書き換えの影響は受けない
- README.md に `/config` 説明とレスポンス例を追記
- 単体テスト 10 件追加（`health-checker/config_handler_test.go`）:
  - GET でランタイム設定を返却
  - HEAD 許可
  - GET/HEAD 以外は 405 + Allow ヘッダ
  - デフォルト値が main() の env 読み取り箇所と一致
  - env による上書き反映
  - 不正値でのデフォルトフォールバック
  - ハンドラは構築時 config をクロージャで保持（後からの env 変更を無視）
  - JSON 形状（`server` ネスト、snake_case、tag drift 検知）
  - 秘匿情報漏れの警戒

## 対応 Issue

Closes #126

## 動作確認

- `cd health-checker && go vet ./...` — pass
- `cd health-checker && go test -v ./...` — pass（新テスト 10 件を含む全 55 件）
- `cd analytics-api && flake8 --max-line-length=120 --exclude=__pycache__ main.py && python -m pytest -q` — pass（309 件）
- `cd api-gateway && npm run lint && npm test` — pass（74 件）

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwWB1t92CR1FGmRzCMSAZf)_