### PR TITLE
feat(analytics-api): 時刻別集計 /metrics/services/{name}/by_hour_of_day を追加

### DIFF
--- a/analytics-api/main.py
+++ b/analytics-api/main.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import FastAPI, HTTPException, Query, Request, Response
@@ -409,6 +410,99 @@ class MetricsStore:
             "service": service,
             "total": len(records_snapshot),
             "by_status": by_status,
+        }
+
+    def service_by_hour_of_day(
+        self,
+        service: str,
+        since: float | None = None,
+        until: float | None = None,
+    ) -> dict | None:
+        """単一サービスの観測を「1 日のうちの時刻 (00〜23, UTC)」でグルーピングして返す。
+
+        `service_by_status` がステータス軸で切るのに対し、こちらは時刻軸で切る。
+        「深夜バッチ時間帯だけ degraded が急増する」「業務時間帯は healthy が多い」
+        のような時刻依存の稼働パターンを、UI 側で全件取得→クライアントビニング
+        することなく 1 リクエストで可視化するためのエンドポイント。
+
+        バケットのキーは `timestamp` (Unix epoch 秒) を UTC 時刻へ変換した
+        2 桁ゼロ詰めの時 (`"00"`〜`"23"`)。populated-only（観測 0 件の時刻は返さない）
+        方針は `service_timeseries` と揃える。
+
+        各バケットの形:
+            {
+                "hour": <"00"..."23">,
+                "count": <件数>,
+                "by_status": {healthy, unhealthy, degraded, unknown},   # 全キー 0 初期化
+                "avg_response_ms": <平均>,
+                "min_response_ms": <最小>,
+                "max_response_ms": <最大>,
+                "p50_response_ms": <p50>,
+                "p95_response_ms": <p95>,
+                "p99_response_ms": <p99>,
+                "first_seen": <バケット内最古 observation の timestamp>,
+                "last_seen":  <バケット内最新 observation の timestamp>,
+            }
+
+        レスポンス全体:
+            {
+                "service": <service>,
+                "total": <since/until 範囲内の全 observation 件数>,
+                "distinct_hours": <populated バケット数>,
+                "by_hour_of_day": [...]   # "00" 昇順（lex 昇順 = 時刻順）
+            }
+
+        対象サービスのレコードが範囲内に 1 件も無い場合は `None` を返す
+        （`service_by_status` と同じ 404 セマンティクス）。
+        """
+        records_snapshot = self.filter(service=service, since=since, until=until)
+        if not records_snapshot:
+            return None
+
+        per_hour: dict[str, dict] = {}
+        for r in records_snapshot:
+            hour_key = datetime.fromtimestamp(r.timestamp, tz=timezone.utc).strftime("%H")
+            bucket = per_hour.setdefault(
+                hour_key,
+                {
+                    "times": [],
+                    "by_status": {s: 0 for s in ALLOWED_STATUSES},
+                    "first_seen": None,
+                    "last_seen": None,
+                },
+            )
+            bucket["times"].append(r.response_time_ms)
+            bucket["by_status"][r.status] = bucket["by_status"].get(r.status, 0) + 1
+            if bucket["first_seen"] is None or r.timestamp < bucket["first_seen"]:
+                bucket["first_seen"] = r.timestamp
+            if bucket["last_seen"] is None or r.timestamp > bucket["last_seen"]:
+                bucket["last_seen"] = r.timestamp
+
+        by_hour_of_day: list[dict] = []
+        for hour_key in sorted(per_hour.keys()):
+            bucket = per_hour[hour_key]
+            times = bucket["times"]
+            sorted_times = sorted(times)
+            count = len(sorted_times)
+            avg = sum(times) / count if count else 0.0
+            by_hour_of_day.append({
+                "hour": hour_key,
+                "count": count,
+                "by_status": bucket["by_status"],
+                "avg_response_ms": round(avg, 2),
+                "min_response_ms": round(sorted_times[0], 2) if sorted_times else 0.0,
+                "max_response_ms": round(sorted_times[-1], 2) if sorted_times else 0.0,
+                "p50_response_ms": round(_percentile(sorted_times, 50), 2),
+                "p95_response_ms": round(_percentile(sorted_times, 95), 2),
+                "p99_response_ms": round(_percentile(sorted_times, 99), 2),
+                "first_seen": bucket["first_seen"],
+                "last_seen": bucket["last_seen"],
+            })
+        return {
+            "service": service,
+            "total": len(records_snapshot),
+            "distinct_hours": len(by_hour_of_day),
+            "by_hour_of_day": by_hour_of_day,
         }
 
     def incidents(
@@ -1844,6 +1938,75 @@ def get_service_by_status(
         )
 
     detail = store.service_by_status(service=normalized, since=since, until=until)
+    if detail is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No metrics found for service '{normalized}'",
+        )
+    return detail
+
+
+@app.get("/metrics/services/{service_name}/by_hour_of_day")
+def get_service_by_hour_of_day(
+    service_name: str,
+    since: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以降（>=）の観測のみ集計",
+    ),
+    until: float | None = Query(
+        default=None,
+        ge=0,
+        description="この Unix timestamp 以前（<=）の観測のみ集計",
+    ),
+):
+    """単一サービスの観測を「1 日のうちの時刻 (UTC 00〜23)」でグルーピングして返す。
+
+    「業務時間帯は healthy が多く、深夜バッチ時間帯だけ degraded が急増する」の
+    ような時刻依存の稼働パターンを、UI 側で全件取得→クライアントビニングする
+    ことなく 1 リクエストで可視化するためのエンドポイント。既存 `/by_status`
+    が status 軸で切るのに対し、こちらは時刻軸で切る対称的な集計。
+
+    バケットキーは `timestamp` を UTC 化した 2 桁ゼロ詰め時刻 (`"00"`〜`"23"`)。
+    lex 昇順 = 時間順が保たれるのでソートは単純。populated-only （観測 0 件の
+    時刻はレスポンスに含めない）方針は `service_timeseries` と揃える。
+
+    レスポンス:
+        {
+          "service": <service_name>,
+          "total": <since/until 範囲内の全 observation 件数>,
+          "distinct_hours": <populated バケット数>,
+          "by_hour_of_day": [
+            {"hour", "count", "by_status", "avg_response_ms", "min", "max",
+             "p50", "p95", "p99", "first_seen", "last_seen"},
+            ...   # "00" から昇順
+          ]
+        }
+
+    各バケットの `by_status` は `ALLOWED_STATUSES` の全キーを 0 初期化で必ず含む
+    （`service_timeseries` のバケットと同じ契約）。対象サービスのレコードが範囲内に
+    1 件も無い場合は 404 を返す（他の `/metrics/services/{name}/*` と揃える）。
+    """
+    if since is not None and until is not None and since > until:
+        raise HTTPException(
+            status_code=400,
+            detail="since must be less than or equal to until",
+        )
+    if since is not None and not math.isfinite(since):
+        raise HTTPException(status_code=400, detail="since must be a finite number")
+    if until is not None and not math.isfinite(until):
+        raise HTTPException(status_code=400, detail="until must be a finite number")
+
+    normalized = service_name.strip()
+    if not normalized:
+        raise HTTPException(status_code=400, detail="service_name must not be blank")
+    if len(normalized) > MAX_SERVICE_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"service_name must be at most {MAX_SERVICE_LENGTH} characters",
+        )
+
+    detail = store.service_by_hour_of_day(service=normalized, since=since, until=until)
     if detail is None:
         raise HTTPException(
             status_code=404,

--- a/analytics-api/test_main.py
+++ b/analytics-api/test_main.py
@@ -2648,6 +2648,165 @@ def test_metrics_store_service_by_status_unit():
     assert s.service_by_status("missing") is None
 
 
+# ---- /metrics/services/{service_name}/by_hour_of_day ----
+#
+# UTC 時刻でビニングした周期集計。`/by_status` と対称的に、populated-only /
+# 404-on-empty / 数値バリデーション / service_name バリデーションを揃える。
+# タイムスタンプは 1970-01-01 UTC の 0:00 を基点に、`H` 時 M 分は
+# `H * 3600 + M * 60` 秒として計算する（テストを読みやすくするため）。
+
+
+def test_service_by_hour_of_day_basic_bucketing():
+    # 03:00 UTC (3*3600=10800) に 2 件、05:30 UTC (5*3600+1800=19800) に 1 件
+    _post_metric_with_timestamp("web", "healthy", 50.0, 10800.0)
+    _post_metric_with_timestamp("web", "healthy", 60.0, 10860.0)   # 03:01 UTC
+    _post_metric_with_timestamp("web", "degraded", 500.0, 19800.0)  # 05:30 UTC
+    _post_metric_with_timestamp("other", "healthy", 1.0, 10800.0)   # 他サービス
+    resp = client.get("/metrics/services/web/by_hour_of_day")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["service"] == "web"
+    assert data["total"] == 3
+    assert data["distinct_hours"] == 2
+    hours = [b["hour"] for b in data["by_hour_of_day"]]
+    # populated-only + lex 昇順 = 時間順
+    assert hours == ["03", "05"]
+    b03 = data["by_hour_of_day"][0]
+    b05 = data["by_hour_of_day"][1]
+    assert b03["count"] == 2
+    assert b03["by_status"]["healthy"] == 2
+    assert b03["by_status"]["degraded"] == 0
+    assert b03["avg_response_ms"] == 55.0
+    assert b03["min_response_ms"] == 50.0
+    assert b03["max_response_ms"] == 60.0
+    assert b03["first_seen"] == 10800.0
+    assert b03["last_seen"] == 10860.0
+    assert b05["count"] == 1
+    assert b05["by_status"]["degraded"] == 1
+    assert b05["by_status"]["healthy"] == 0
+    assert b05["first_seen"] == 19800.0
+    assert b05["last_seen"] == 19800.0
+
+
+def test_service_by_hour_of_day_populated_only():
+    # populated-only: 観測が無い時間帯は返さない (timeseries と同じ方針)
+    _post_metric_with_timestamp("web", "healthy", 10.0, 3600.0)   # 01 時
+    _post_metric_with_timestamp("web", "healthy", 10.0, 43200.0)  # 12 時
+    body = client.get("/metrics/services/web/by_hour_of_day").json()
+    hours = [b["hour"] for b in body["by_hour_of_day"]]
+    assert hours == ["01", "12"]
+    assert body["distinct_hours"] == 2
+
+
+def test_service_by_hour_of_day_bucket_by_status_has_all_keys():
+    # 各バケットの by_status は `ALLOWED_STATUSES` の全キーを 0 初期化で含む
+    _post_metric_with_timestamp("web", "healthy", 10.0, 3600.0)
+    body = client.get("/metrics/services/web/by_hour_of_day").json()
+    bucket = body["by_hour_of_day"][0]
+    assert set(bucket["by_status"].keys()) == {"healthy", "unhealthy", "degraded", "unknown"}
+    assert bucket["by_status"]["healthy"] == 1
+    assert bucket["by_status"]["unhealthy"] == 0
+    assert bucket["by_status"]["degraded"] == 0
+    assert bucket["by_status"]["unknown"] == 0
+
+
+def test_service_by_hour_of_day_404_when_no_records():
+    resp = client.get("/metrics/services/missing/by_hour_of_day")
+    assert resp.status_code == 404
+
+
+def test_service_by_hour_of_day_404_when_only_other_services():
+    _post_metric_with_timestamp("other", "healthy", 1.0, 3600.0)
+    resp = client.get("/metrics/services/web/by_hour_of_day")
+    assert resp.status_code == 404
+
+
+def test_service_by_hour_of_day_since_until_filter():
+    # 01 時 / 05 時 / 20 時 の 3 件。since/until で 05 時のみ残す。
+    _post_metric_with_timestamp("web", "healthy", 10.0, 3600.0)    # 01:00 UTC
+    _post_metric_with_timestamp("web", "degraded", 200.0, 18000.0)  # 05:00 UTC
+    _post_metric_with_timestamp("web", "healthy", 11.0, 72000.0)   # 20:00 UTC
+    body = client.get(
+        "/metrics/services/web/by_hour_of_day?since=10000&until=30000"
+    ).json()
+    assert body["total"] == 1
+    assert body["distinct_hours"] == 1
+    assert body["by_hour_of_day"][0]["hour"] == "05"
+    assert body["by_hour_of_day"][0]["by_status"]["degraded"] == 1
+
+
+def test_service_by_hour_of_day_404_when_filter_excludes_all():
+    _post_metric_with_timestamp("web", "healthy", 1.0, 3600.0)
+    resp = client.get("/metrics/services/web/by_hour_of_day?since=100000")
+    assert resp.status_code == 404
+
+
+def test_service_by_hour_of_day_rejects_since_greater_than_until():
+    _post_metric_with_timestamp("svc", "healthy", 1.0, 3600.0)
+    resp = client.get("/metrics/services/svc/by_hour_of_day?since=500&until=100")
+    assert resp.status_code == 400
+
+
+def test_service_by_hour_of_day_rejects_blank_path():
+    resp = client.get("/metrics/services/%20/by_hour_of_day")
+    assert resp.status_code == 400
+
+
+def test_service_by_hour_of_day_percentiles_single_value():
+    # 1 件のみのバケットでは p50=p95=p99=min=max=avg
+    _post_metric_with_timestamp("web", "healthy", 42.0, 3600.0)
+    body = client.get("/metrics/services/web/by_hour_of_day").json()
+    bucket = body["by_hour_of_day"][0]
+    assert bucket["count"] == 1
+    assert bucket["p50_response_ms"] == 42.0
+    assert bucket["p95_response_ms"] == 42.0
+    assert bucket["p99_response_ms"] == 42.0
+    assert bucket["avg_response_ms"] == 42.0
+    assert bucket["min_response_ms"] == 42.0
+    assert bucket["max_response_ms"] == 42.0
+
+
+def test_service_by_hour_of_day_boundary_hours():
+    # 00:00:01 UTC (= epoch 1、`timestamp > 0` の制約を満たす最小値) と
+    # 23:59:59 UTC (= 86399) が別バケット (`"00"` / `"23"`) へ落ちること。
+    # 「1 日の境界」で日跨ぎのバケット割り当てが崩れないかの回帰。
+    _post_metric_with_timestamp("web", "healthy", 10.0, 1.0)
+    _post_metric_with_timestamp("web", "healthy", 20.0, 86399.0)
+    body = client.get("/metrics/services/web/by_hour_of_day").json()
+    hours = [b["hour"] for b in body["by_hour_of_day"]]
+    assert hours == ["00", "23"]
+    assert body["distinct_hours"] == 2
+
+
+def test_metrics_store_service_by_hour_of_day_unit():
+    s = MetricsStore()
+    s.add(MetricRecord(service="web", status="healthy", response_time_ms=50.0, timestamp=3600.0))    # 01
+    s.add(MetricRecord(service="web", status="degraded", response_time_ms=500.0, timestamp=18000.0))  # 05
+    s.add(MetricRecord(service="other", status="healthy", response_time_ms=1.0, timestamp=3600.0))   # 他サービス
+    result = s.service_by_hour_of_day("web")
+    assert result is not None
+    assert result["total"] == 2
+    assert result["distinct_hours"] == 2
+    assert [b["hour"] for b in result["by_hour_of_day"]] == ["01", "05"]
+    assert result["by_hour_of_day"][0]["by_status"]["healthy"] == 1
+    assert result["by_hour_of_day"][1]["by_status"]["degraded"] == 1
+    assert s.service_by_hour_of_day("missing") is None
+
+
+def test_service_by_hour_of_day_same_hour_across_days_merges():
+    # 同じ「時」でも別日 (86400 秒差) の観測は同一バケットにマージされる。
+    # これは仕様: 「1 日のうちどの時間帯」の集計なので、日を跨いだ 03 時は同じバケット。
+    _post_metric_with_timestamp("web", "healthy", 10.0, 10800.0)          # day 0, 03 UTC
+    _post_metric_with_timestamp("web", "healthy", 20.0, 10800.0 + 86400)  # day 1, 03 UTC
+    body = client.get("/metrics/services/web/by_hour_of_day").json()
+    assert body["distinct_hours"] == 1
+    bucket = body["by_hour_of_day"][0]
+    assert bucket["hour"] == "03"
+    assert bucket["count"] == 2
+    assert bucket["first_seen"] == 10800.0
+    assert bucket["last_seen"] == 10800.0 + 86400
+
+
 # ---- /metrics/services/{service_name}/latest ----
 
 


### PR DESCRIPTION
## 変更概要

- `MetricsStore.service_by_hour_of_day` を追加。`timestamp` (Unix epoch 秒) を UTC 化した 2 桁ゼロ詰め時刻 (`"00"`〜`"23"`) でバケット集約する
- `GET /metrics/services/{service_name}/by_hour_of_day` エンドポイントを新設
- 各バケット: `hour` / `count` / `by_status` (全キー 0 初期化) / `avg_response_ms` / `min` / `max` / `p50` / `p95` / `p99` / `first_seen` / `last_seen`
- レスポンス: `{ service, total, distinct_hours, by_hour_of_day: [...] }`
- 引数規約 (`since` / `until` + 数値バリデーション) / 404 セマンティクス / populated-only 集計方針は既存 `/by_status` と統一
- `datetime` import を追加

## 追加テスト（13 件）

- `test_service_by_hour_of_day_basic_bucketing` — 複数時刻の観測を UTC 時刻ごとにビニング、`hours` は昇順、`by_status` 各キー、`first_seen`/`last_seen`
- `test_service_by_hour_of_day_populated_only` — 観測 0 件の時間帯はレスポンスに含めない
- `test_service_by_hour_of_day_bucket_by_status_has_all_keys` — 各バケットの `by_status` は `ALLOWED_STATUSES` 全キーを 0 初期化で必ず含む
- `test_service_by_hour_of_day_404_when_no_records` — 未存在サービス → 404
- `test_service_by_hour_of_day_404_when_only_other_services` — 別サービスのみ → 404
- `test_service_by_hour_of_day_since_until_filter` — ウィンドウフィルタ
- `test_service_by_hour_of_day_404_when_filter_excludes_all` — フィルタで全件除外 → 404
- `test_service_by_hour_of_day_rejects_since_greater_than_until` — 400
- `test_service_by_hour_of_day_rejects_blank_path` — 400
- `test_service_by_hour_of_day_percentiles_single_value` — 1 件バケットで p50=p95=p99=avg=min=max
- `test_service_by_hour_of_day_boundary_hours` — 00 時 / 23 時境界
- `test_metrics_store_service_by_hour_of_day_unit` — `MetricsStore` 直呼び出し
- `test_service_by_hour_of_day_same_hour_across_days_merges` — 日跨ぎで同じ「時」のバケットは 1 つにマージ

## 対応 Issue

Closes #125

## 動作確認手順

```bash
cd analytics-api
pip install -r requirements-dev.txt
flake8 --max-line-length=120 --exclude=__pycache__ main.py   # 0 issues
pytest -v                                                     # 322 passed (追加 13 + 既存 309)
```

ローカルで両コマンド緑を確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_015qBJTZfgN1xA5kiFr7shxF)_