### PR TITLE
chore: Dependabot 設定を追加 (Python/Node.js/Go/Actions/Docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,119 @@
+# Dependabot 設定
+# 全マイクロサービスの依存パッケージを週次で監視する。
+# 各エコシステムごとに個別の PR が生成される。
+
+version: 2
+
+updates:
+  # analytics-api (Python)
+  - package-ecosystem: "pip"
+    directory: "/analytics-api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(analytics-api)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+      - "analytics-api"
+
+  # api-gateway (Node.js / TypeScript)
+  - package-ecosystem: "npm"
+    directory: "/api-gateway"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(api-gateway)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "api-gateway"
+
+  # health-checker (Go)
+  - package-ecosystem: "gomod"
+    directory: "/health-checker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(health-checker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+      - "health-checker"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Docker (各サービスの Dockerfile を監視)
+  - package-ecosystem: "docker"
+    directory: "/analytics-api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(analytics-api)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/api-gateway"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(api-gateway)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/health-checker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(health-checker)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## 変更概要

- `.github/dependabot.yml` を新規追加
  - **Python (pip)**: `analytics-api/requirements.txt` `requirements-dev.txt` を監視
  - **Node.js (npm)**: `api-gateway/package.json` を監視
  - **Go modules (gomod)**: `health-checker/go.mod` を監視
  - **GitHub Actions**: `.github/workflows/*.yml` の action バージョンを監視
  - **Docker**: 各サービスの Dockerfile (Python/Node/Go ベースイメージ) を監視
- スケジュール: 週次月曜 09:00 JST
- PR 最大数: エコシステム毎に 3〜5 に制限
- コミットメッセージ: `chore(<service>):` プレフィクスでスコープ付き

## 対応 Issue

Closes #131

## 動作確認手順

1. YAML 構文チェック済み（`python3 -c "import yaml; yaml.safe_load(...)"` パス）
2. 既存 CI (`ci.yml`) には変更なし → 挙動不変
3. マージ後、GitHub の "Insights > Dependency graph > Dependabot" に 7 つのエコシステムが認識される想定
4. 既存の Python/Node/Go/Docker 依存に対する Dependabot PR は既存 CI (`test-python`/`test-go`/`test-typescript`/`docker-build`) で自動検証される

## リスク・注意

- 純粋な追加のみ。既存コード・CI ワークフローには影響しない。
- Docker エコシステムでは、GitHub Actions を daemonized で使う想定ではなく、Dockerfile 内の `FROM` ベースイメージのバージョンアップを対象とする。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiM5GCnQE623Sqtget5Qse)_