### PR TITLE
docs: SECURITY.md を追加して脆弱性報告経路と脅威モデルを明文化

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## 対応バージョン
+
+`main` ブランチのみサポート対象です。過去のタグ・ビルドに対するセキュリティ修正のバックポートは行いません。
+
+## 脆弱性の報告
+
+セキュリティに関わる問題は **公開 Issue に投稿しないでください**。
+GitHub の [Security Advisories](https://github.com/mohadayo/pulseboard/security/advisories/new) 経由で
+非公開で報告してください。
+
+### 報告に含めてほしい内容
+
+- 対象コミット SHA / タグ
+- 対象サービス (`analytics-api` / `api-gateway` / `health-checker` / `docker-compose`)
+- 再現手順（可能なら最小 HTTP リクエスト / 設定ファイル例）
+- 想定される影響（機密漏洩・改ざん・DoS・権限昇格 等）
+- （任意）修正案・PoC
+
+24〜72 時間以内に一次応答することを目標とします。
+
+## 脅威モデル
+
+PulseBoard は複数マイクロサービス（Python の `analytics-api`、Go の `health-checker`、
+TypeScript の `api-gateway`）を Docker Compose で連携させたリアルタイムヘルス監視ダッシュボードです。
+以下のカテゴリを主要な脅威として扱います。
+
+1. **入力バリデーション回避** — API に細工リクエストを送りエラー系パスやパーサを崩す
+2. **依存パッケージの既知脆弱性** — Python/Node.js/Go/Docker ベースイメージ経由の CVE
+3. **設定漏洩** — 秘密鍵・API トークン・DB 認証情報のリポジトリ / ログ / イメージへの混入
+4. **ネットワーク境界侵害** — 内部サービスが誤って外部公開ポートに晒される
+5. **DoS 相当のリソース枯渇** — 上限のないリクエスト受付・過大なペイロード
+
+## 設計上の防御ライン
+
+### 依存パッケージ管理
+
+- Dependabot によって `pip` / `npm` / `gomod` / `github-actions` / `docker` の各エコシステムを週次監視
+- CI (`.github/workflows/ci.yml`) が Dependabot PR に対しても実行され、互換性を自動検証
+
+### CI ゲート
+
+- Python: `flake8` + `pytest`
+- Go: `go vet` + `go test`
+- TypeScript: `npm run lint` + `npm test`
+- Docker: `docker compose build`
+- 全ジョブが緑になるまで PR をマージしない運用
+
+### コンテナ境界
+
+- 各サービスは独立した Dockerfile で最小権限イメージを構築
+- `docker-compose.yml` で公開ポートを明示的に定義し、意図しないポート露出を防止
+- 秘密情報は環境変数として注入し、イメージや Git 履歴に含めない
+
+## セキュリティに影響する PR のレビュー観点
+
+以下の変更を含む PR は最低 1 名のセキュリティレビューを必須とします：
+
+- 認証・認可ロジック（`api-gateway` のミドルウェア、`analytics-api` の認可判定 等）
+- 入力パーサ・シリアライザ（JSON / YAML / HTTP ヘッダ処理）
+- 外部通信先 (`http.Get` / `requests.get` / `fetch` の URL 生成)
+- Docker イメージのベース・実行ユーザ (`USER` 指定) の変更
+- `.env.example` / `docker-compose.yml` の環境変数・ポート追加削除
+- CI ワークフロー (`.github/workflows/*.yml`) の権限昇格 (`permissions:` / `secrets:` 追加)
+
+対応するテスト（`analytics-api/test_main.py` / `health-checker/*_test.go` /
+`api-gateway/src/**/*.test.ts`）の追加・更新を伴わない防御ラインの緩和は原則としてマージしません。
+
+## 開発時のシークレット管理
+
+- `.env.example` は雛形のみを含み、実際の値は各開発者ローカルの `.env` にのみ配置する
+- `.env` は `.gitignore` に含まれており、リポジトリにはコミットしない
+- 万一シークレットがコミットされた場合は、直ちに該当キーをローテーションした上で
+  上記 Security Advisories 経由で報告してください（履歴からの完全除去だけでは無効化されません）


### PR DESCRIPTION
## 変更概要

- `SECURITY.md` を新規追加
  - **対応バージョン**: `main` のみサポート、過去タグへのバックポート方針を明記
  - **脆弱性の報告経路**: GitHub Security Advisories への非公開報告を推奨
  - **脅威モデル**: 入力バリデーション回避 / 依存脆弱性 / 設定漏洩 / DoS 等
  - **防御ライン**: Dependabot / CI ゲート / コンテナ境界 の位置付け
  - **レビュー観点**: 認証認可・入力パーサ・外部通信・Docker `USER` 変更 等
  - **シークレット管理**: `.env.example` / `.env` の運用と誤コミット時の対応

## 対応 Issue

Closes #133

## 動作確認手順

1. Markdown 構文チェック: heading 階層 (`#` は 1 回のみ) / trailing whitespace 無しをローカルで確認済
2. 既存コードには一切変更なし → 挙動不変
3. マージ後、GitHub 上部の「Security」タブに `Reporting policy` として SECURITY.md がリンクされる

## リスク・注意

- 純粋な追加のみ。既存コード・CI ワークフローには影響しない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2T11q1hZgyLFdbffFTGVn)_