### PR TITLE
chore: `.editorconfig` を追加してエディタ間フォーマットを統一

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,48 @@
+# EditorConfig helps maintain consistent coding styles across editors and IDEs.
+# https://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Python (PEP 8: 4 spaces)
+[*.py]
+indent_size = 4
+
+# Go (gofmt uses tabs)
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[go.{mod,sum}]
+indent_style = tab
+
+# Makefile requires tabs for recipes
+[{Makefile,makefile,GNUmakefile}]
+indent_style = tab
+
+# TypeScript / JavaScript
+[*.{ts,tsx,js,jsx,mjs,cjs}]
+indent_size = 2
+
+# YAML / JSON
+[*.{yml,yaml,json}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+indent_size = 2
+
+# Dockerfile
+[{Dockerfile,Dockerfile.*}]
+indent_size = 2
+
+# Markdown: keep trailing spaces (two-space line break)
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## 変更概要

- `.editorconfig` をルート直下に新規追加
  - 既定: 2 スペース / LF / UTF-8 / 末尾空白トリム / 末尾改行付与
  - `*.py`: 4 スペース (PEP 8)
  - `*.go` / `go.{mod,sum}`: タブ (`gofmt` 準拠)
  - `Makefile`: タブ (recipe が必須)
  - `*.{ts,tsx,js,jsx,mjs,cjs}` / `*.{yml,yaml,json}` / `*.sh` / `Dockerfile`: 2 スペース
  - `*.md`: 末尾空白を保持 (2 スペース改行に対応)

## 対応 Issue

Closes #137

## 動作確認手順

1. `.editorconfig` 構文チェック済み (セクション & `root = true` の存在を確認)
2. 既存 CI (`.github/workflows/ci.yml`) には変更なし
   - `test-python` (`flake8` + `pytest` on `analytics-api`)
   - `test-go` (`go vet` + `go test` on `health-checker`)
   - `test-typescript` (`npm run lint` + `npm test` on `api-gateway`)
   - `docker-build` (`docker compose build`)
3. 既存ソースファイル (`analytics-api/main.py` / `health-checker/main.go` / `api-gateway/src/**`) には変更を加えていないため挙動不変

## リスク・注意

- 純粋な追加のみ。既存コード・ビルド設定には影響しない。
- EditorConfig 非対応エディタでは無視されるだけで、既存ワークフローに悪影響なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBEgkvFMUNYjyaMBtfeyDf)_