### PR TITLE
chore(ci): concurrency グループと timeout-minutes を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# 同一ワークフロー・同一 ref (PR ブランチや main) で新しいジョブが起動したら、
+# 進行中の古いジョブをキャンセルする。PR に短時間で連続 push した場合の
+# 実行枠・実行時間の無駄を削減する。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-python:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: analytics-api
@@ -23,6 +31,7 @@ jobs:
 
   test-go:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: health-checker
@@ -36,6 +45,7 @@ jobs:
 
   test-typescript:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: api-gateway
@@ -50,6 +60,7 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [test-python, test-go, test-typescript]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 変更概要

- `.github/workflows/ci.yml` に workflow レベルの `concurrency` グループを追加
  - `group: ${{ github.workflow }}-${{ github.ref }}`
  - `cancel-in-progress: true`
  - 同一 PR ブランチ（あるいは main）への連続 push で、進行中の古いジョブをキャンセルする
- 各ジョブに `timeout-minutes` を設定 (デフォルト 360 分 → 妥当な上限に短縮)
  - `test-python` / `test-go` / `test-typescript`: 10 分
  - `docker-build`: 20 分
- 既存の `test-python` / `test-go` / `test-typescript` / `docker-build` 各ジョブのステップ順序・runner・setup アクションのバージョン・実行コマンドはロジック変更なし

## 対応 Issue

Closes #139

## 動作確認手順

1. YAML 構文チェック済み (`python3 yaml.safe_load` パス)
2. 構造チェック済み: `concurrency.group` / `concurrency.cancel-in-progress` が期待値、4 ジョブ全てに `timeout-minutes` が設定されていること
3. ジョブ本体のコマンド (`pip install` / `flake8` / `pytest` / `go vet` / `go test` / `npm ci` / `npm run lint` / `npm test` / `docker compose build`) は変更なし → 実行結果に影響なし
4. マージ後は、PR に連続 push した際に古いジョブが自動でキャンセルされ、GitHub Actions のジョブ一覧で `Canceled` 表示になる想定

## リスク・注意

- `concurrency` は同一 `ref` 単位でキャンセルするため、`main` への複数の push（例: 連続マージ）でも古い CI がキャンセルされる。ホットな main で稀に成功結果を早く得たい場合は、main のみ `cancel-in-progress: false` に切り替える余地があるが、まずはシンプルに開始する。
- `timeout-minutes` は現状の CI 実行時間（数分オーダー）に対して十分な余裕を持たせている。将来テストが増えて時間内に収まらなくなった場合はジョブ単位で緩めれば良い。

---

**関連する既存 PR との差異**: PR #138 (`.editorconfig` 追加) / PR #132 (Dependabot 設定追加) はいずれもリポジトリ設定の追加であり、ci.yml 自体には触れていないため、本 PR とファイル競合しない。


---
_Generated by [Claude Code](https://claude.ai/code/session_014itB1YKBAQ2dY2rupYhSS5)_