### PR TITLE
docs: MIT LICENSE ファイルを追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 moha (mohadayo)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 変更概要

- ルート直下に `LICENSE` (MIT License, Copyright 2026 moha / mohadayo) を新規追加

## 変更内容の詳細

- OSI 標準の MIT License テンプレートをそのまま使用
- GitHub が `LICENSE` を自動検出し、リポジトリメタデータにライセンスバッジを表示するようになる

## 対応 Issue

Closes #145

## 影響範囲

- [x] ドキュメントのみ

## 動作確認手順

1. マージ後、リポジトリトップに MIT License バッジが表示されることを確認
2. `analytics-api/` / `api-gateway/` / `health-checker/` のいずれのソース・テストにも変更なしを確認
3. 既存 CI (`test-python` / `test-go` / `test-typescript` / `docker-build`) が全て緑であることを確認

## リスク・注意点

- 純粋な追加のみ。既存コード・CI・Docker ビルドには影響なし。

## チェックリスト

- [x] 静的解析への影響なし (ソースコード未変更)
- [x] テストへの影響なし (テストファイル未変更)
- [x] テスト追加は不要 (`LICENSE` テキストファイルのため)
- [x] README への影響なし (別途 README 側でリンクを追加する余地はあるが本 PR ではスコープ外)
- [x] `.env.example` への影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFbPCYSrLNb3oUoAki8Aka)_