### PR TITLE
chore(ci): pip / npm 依存キャッシュを追加して CI を高速化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          # pip の依存キャッシュを有効化。requirements-dev.txt のハッシュが
+          # キャッシュキーになるため、依存追加/更新時のみキャッシュが再生成される。
+          cache: pip
+          cache-dependency-path: analytics-api/requirements-dev.txt
       - run: pip install -r requirements-dev.txt
       - run: flake8 --max-line-length=120 --exclude=__pycache__ main.py
       - run: pytest -v
@@ -54,6 +58,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          # npm の依存キャッシュを有効化。package-lock.json のハッシュが
+          # キャッシュキーになるため、依存追加/更新時のみキャッシュが再生成される。
+          cache: npm
+          cache-dependency-path: api-gateway/package-lock.json
       - run: npm ci
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## 変更概要

`.github/workflows/ci.yml` に `actions/setup-python@v5` / `actions/setup-node@v4` の組み込みキャッシュ機能を追加し、CI 実行時の依存ダウンロードコストを削減する。

## 変更内容の詳細

- `test-python` ジョブに `cache: pip` と `cache-dependency-path: analytics-api/requirements-dev.txt` を追加
- `test-typescript` ジョブに `cache: npm` と `cache-dependency-path: api-gateway/package-lock.json` を追加
- `test-go` は `health-checker/go.mod` に外部依存が無く `go.sum` も存在しないため、今回はキャッシュ設定を追加しない
- `docker-build` ジョブは変更しない

キャッシュキーには依存記述ファイル (`requirements-dev.txt` / `package-lock.json`) のハッシュが使われるため、依存追加/更新時のみキャッシュが再生成される。既存の `pip install -r ...` / `npm ci` の挙動は変わらず、失敗時の fallback も従来通り動作する。

## 対応 Issue

Closes #151

## 影響範囲

- [ ] `analytics-api/` (Python)
- [ ] `api-gateway/` (TypeScript)
- [ ] `health-checker/` (Go)
- [x] `.github/` (CI / メタデータ)
- [ ] `docker-compose.yml` / インフラ
- [ ] ドキュメントのみ

## 動作確認手順

1. 本 PR の CI (`test-python` / `test-typescript`) が緑になることを確認
2. 初回実行後、次回以降の実行で `Cache restored successfully` (setup-python) / `Cache restored from key` (setup-node) のログが出ることを確認
3. `requirements-dev.txt` / `package-lock.json` を変更した PR ではキャッシュキーが変わり、キャッシュミス→再インストールが行われることを確認 (別 PR で観測)

## リスク・注意点

- キャッシュ機能は setup-* アクションの標準機能で、失敗しても `pip install` / `npm ci` は通常通り動作する (fail-open)
- キャッシュサイズは GitHub のリポジトリキャッシュ上限 (10GB) の範囲で自動的に GC される
- ロールバックは本 PR を revert するだけで良い

## チェックリスト

- [x] `flake8` / `npm run lint` / `go vet` などの静的解析がローカルで緑 (CI 設定のみの変更、実コードに変更なし)
- [x] 該当するテスト (`pytest` / `npm test` / `go test`) がローカルで緑 (実コードに変更なし)
- [x] 変更に応じたテストを追加した（またはその必要が無いことを本文で説明）: CI 設定のみのためテスト追加不要
- [x] README / ドキュメントを更新した（必要な場合）: 挙動は変わらないため更新不要
- [x] 環境変数を追加・変更した場合、`.env.example` を更新した: 環境変数の変更なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGdR7XqUmG3jNW4nUXsMrY)_