### PR TITLE
feat(api-gateway): SIGTERM/SIGINT を受けてグレースフルシャットダウンする

### DIFF
--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -348,4 +348,4 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   res.status(500).json({ error: "Internal server error" });
 });
 
-export { app, ANALYTICS_URL, CHECKER_URL, MAX_REQUEST_BODY, STATUS_PROBE_TIMEOUT };
+export { app, logger, ANALYTICS_URL, CHECKER_URL, MAX_REQUEST_BODY, STATUS_PROBE_TIMEOUT };

--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -1,7 +1,45 @@
-import { app } from "./app";
+import { app, logger } from "./app";
 
-const PORT = process.env.GATEWAY_PORT || 8000;
+const PORT = parseInt(process.env.GATEWAY_PORT || "8000", 10);
+// SIGTERM 受信後、進行中リクエストの完了を待つ最大時間 (ms)。
+// Kubernetes の既定 grace period (30s) より短めに設定し、
+// SIGKILL が飛ぶ前に確実にプロセスを終了させる。
+const SHUTDOWN_TIMEOUT_MS = parseInt(
+  process.env.SHUTDOWN_TIMEOUT_MS || "10000",
+  10,
+);
 
-app.listen(PORT, () => {
-  console.log(`[INFO] API Gateway listening on port ${PORT}`);
+const server = app.listen(PORT, () => {
+  logger.info("API Gateway listening", { port: PORT });
 });
+
+// SIGTERM / SIGINT を受けたら新規接続の受付を止め、進行中リクエストを
+// 完了させたうえで終了する。タイムアウト超過時は強制終了 (exit 1)。
+// Docker/Kubernetes 環境でのローリングアップデート中に、リクエストの
+// 途中切断や 5xx を発生させないための実装。
+function shutdown(signal: string): void {
+  logger.info("Received shutdown signal", { signal });
+  const forceExit = setTimeout(() => {
+    logger.error("Graceful shutdown timed out, forcing exit", {
+      timeout_ms: SHUTDOWN_TIMEOUT_MS,
+    });
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  // 待機用タイマー自体でイベントループを塞がないよう unref する
+  // — 進行中リクエストが早期に完了した際、タイマーが原因でプロセスが
+  // 生き残り続けるのを防ぐ。
+  forceExit.unref();
+
+  server.close((err) => {
+    clearTimeout(forceExit);
+    if (err) {
+      logger.error("Error during server shutdown", { error: err.message });
+      process.exit(1);
+    }
+    logger.info("Server closed cleanly");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## 変更概要

- api-gateway に SIGTERM/SIGINT ハンドラを追加し、Docker/Kubernetes 停止時のグレースフルシャットダウンを実装

## 変更内容の詳細

- `SIGTERM` / `SIGINT` を受信したら `server.close()` を呼び出し、新規接続の受付を止めつつ進行中リクエストの完了を待つ
- `SHUTDOWN_TIMEOUT_MS`（既定 10s、環境変数で調整可能）を超過した場合は `process.exit(1)` で強制終了 — Kubernetes の grace period 内に確実にプロセスを終了させる
- 強制終了用の `setTimeout` は `.unref()` してイベントループを塞がないようにする
- `PORT` を `parseInt` で数値化（旧実装は `process.env.GATEWAY_PORT || 8000` で string と number の混在型だった）
- `console.log` を winston ロガーに置き換え、リポジトリ全体の JSON ログ形式に統一
- `app.ts` から `logger` を export し、`index.ts` から再利用可能にする

## 対応 Issue

Closes #153

## 影響範囲

- [ ] `analytics-api/` (Python)
- [x] `api-gateway/` (TypeScript)
- [ ] `health-checker/` (Go)
- [ ] `.github/` (CI / メタデータ)
- [ ] `docker-compose.yml` / インフラ
- [ ] ドキュメントのみ

## 動作確認手順

1. `cd api-gateway && npm ci`
2. `npm run lint` — エラー無し
3. `npx tsc --noEmit` — エラー無し
4. `npm test` — 85 tests / 1 test suite すべてグリーン
5. （動作確認）`npm run build && node dist/index.js` で起動し、別ターミナルから `kill -TERM <pid>`。ログに `Received shutdown signal` → `Server closed cleanly` が出力され、exit code 0 で終了することを確認

## リスク・注意点

- `PORT` を string → number に変更した点は `app.listen` の型が両方受け付けるため既存挙動に影響なし
- 新規環境変数 `SHUTDOWN_TIMEOUT_MS` は未設定時に既定 10000ms で動作するため、既存デプロイの設定変更は不要
- `console.log` から winston への移行に伴い、`api-gateway listening on port` のログ形式が JSON になる（他のログと同じ形式に統一）

## チェックリスト

- [x] `flake8` / `npm run lint` / `go vet` などの静的解析がローカルで緑
- [x] 該当するテスト (`pytest` / `npm test` / `go test`) がローカルで緑
- [x] 変更に応じたテストを追加した（またはその必要が無いことを本文で説明）— `index.ts` は起動エントリで既存の単体テスト対象外。シャットダウンハンドラは実プロセスに依存するため、単体テストではなく動作確認手順の 5 で検証
- [ ] README / ドキュメントを更新した（必要な場合）
- [ ] 環境変数を追加・変更した場合、`.env.example` を更新した

---
_Generated by [Claude Code](https://claude.ai/code/session_01Achapz3fsaVGZjAZE5R1Aw)_