### PR TITLE
docs: API Gateway の環境変数を README と .env.example に追記

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ LOG_LEVEL=INFO
 # METRICS_DEFAULT_LIMIT=100
 # METRICS_MAX_LIMIT=1000
 
+# API Gateway
+# 以下は既定値で動作するため通常は設定不要。ネットワーク事情や
+# ペイロードサイズに合わせて上書きしたい場合のみ有効化する。
+# PROXY_TIMEOUT=5000                 # analytics-api / health-checker への上流呼び出しタイムアウト（ミリ秒）
+# STATUS_PROBE_TIMEOUT=3000          # /api/status から各サービスの /health を叩く際のタイムアウト（ミリ秒）
+# MAX_REQUEST_BODY=256kb             # express.json が受け付ける最大 JSON ボディサイズ（bytes 互換文字列）
+# SHUTDOWN_TIMEOUT_MS=10000          # SIGTERM 受信後、進行中リクエストの完了を待つ最大時間（ミリ秒）
+
 # Health Checker
 # CHECK_INTERVAL_SECONDS=0  # >0 でバックグラウンド定期チェックを有効化（0 / 未設定で無効）
 # METRIC_REPORT_MAX_ATTEMPTS=3

--- a/README.md
+++ b/README.md
@@ -482,6 +482,10 @@ All services are configured via environment variables. See [`.env.example`](.env
 | `MAX_RECORDS` | `10000` | Analytics API: 保存するメトリクスの最大件数 |
 | `METRICS_DEFAULT_LIMIT` | `100` | Analytics API: `GET /metrics` のデフォルト返却件数 |
 | `METRICS_MAX_LIMIT` | `1000` | Analytics API: `GET /metrics` の `limit` 上限 |
+| `PROXY_TIMEOUT` | `5000` | API Gateway: analytics-api / health-checker への上流プロキシ呼び出しの HTTP タイムアウト（ミリ秒） |
+| `STATUS_PROBE_TIMEOUT` | `3000` | API Gateway: `/api/status` から各サービス `/health` を叩く際のタイムアウト（ミリ秒）。`PROXY_TIMEOUT` より短めに設定し、集約 API が遅延しても素早く応答できるようにする |
+| `MAX_REQUEST_BODY` | `256kb` | API Gateway: `express.json` が受け付ける最大 JSON ボディサイズ。`bytes` 互換の文字列（例: `512kb`, `2mb`）を指定 |
+| `SHUTDOWN_TIMEOUT_MS` | `10000` | API Gateway: SIGTERM 受信後、進行中リクエストの完了を待つ最大時間（ミリ秒）。超過時は `exit 1` で強制終了 |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Health Checker: graceful shutdown 待機時間（秒） |
 | `CHECKER_READ_HEADER_TIMEOUT` | `5` | Health Checker: HTTP リクエストヘッダ読み取りタイムアウト（秒） |
 | `CHECKER_READ_TIMEOUT` | `15` | Health Checker: HTTP リクエスト全体の読み取りタイムアウト（秒） |


### PR DESCRIPTION
Closes #155

## 変更概要

`api-gateway/src/app.ts` および `api-gateway/src/index.ts` で実装済みだが、README の Configuration 表と `.env.example` のどちらにも記載されていなかった以下 4 変数を追記した。オペレータがチューニング可能なパラメータの存在に気づけるようにする。

| 変数 | 既定値 | 用途 |
|------|--------|------|
| `PROXY_TIMEOUT` | `5000` (ms) | 上流プロキシ呼び出しの HTTP タイムアウト |
| `STATUS_PROBE_TIMEOUT` | `3000` (ms) | `/api/status` の `/health` プローブタイムアウト |
| `MAX_REQUEST_BODY` | `256kb` | `express.json` の受け付ける最大 JSON ボディサイズ |
| `SHUTDOWN_TIMEOUT_MS` | `10000` (ms) | SIGTERM 受信後の進行中リクエスト待機上限 |

### 変更ファイル
- `README.md` — Configuration 表に API Gateway 用の 4 行を挿入。書式・言語トーンは既存行に合わせる。
- `.env.example` — `# API Gateway` セクションを追加し、コメントアウトで 4 変数のサンプル行と単位を記載。

### コミット構成（関心事 1 コミット / 1 ファイル）
1. `docs: README の Configuration 表に API Gateway 用の環境変数 4 件を追記`
2. `docs: .env.example に API Gateway セクションを追加`

### スコープ外
- コード（`api-gateway/src/*.ts` 等）は変更しない
- CI ワークフロー（`.github/workflows/*`）は変更しない
- 既定値そのものの変更は行わない（純粋なドキュメント同期）

## 動作確認手順

ドキュメントのみの変更のため、以下の目視レビューで十分。

1. `README.md` の Configuration 表を開き、`PROXY_TIMEOUT` / `STATUS_PROBE_TIMEOUT` / `MAX_REQUEST_BODY` / `SHUTDOWN_TIMEOUT_MS` の 4 行が Analytics API と Health Checker のブロック間に追加されていること。
2. 各行の既定値がコード側の実装値と一致していることを、`api-gateway/src/app.ts`（`PROXY_TIMEOUT` / `STATUS_PROBE_TIMEOUT` / `MAX_REQUEST_BODY`）および `api-gateway/src/index.ts`（`SHUTDOWN_TIMEOUT_MS`）と付き合わせて確認する。
3. `.env.example` に `# API Gateway` セクションが追加され、4 変数がコメントアウト状態で列挙されていること。既定値で動作するため通常は設定不要である旨のコメントが添えられていること。
4. `cp .env.example .env` を実行しても新しいコメント行のみが増え、既存のアクティブ設定（`ANALYTICS_PORT` 等）に副作用が無いこと。

## CI への影響

ドキュメント（`README.md` / `.env.example`）のみの変更で、`.github/workflows/ci.yml` の対象パス（`analytics-api/` / `health-checker/` / `api-gateway/`）には触れていないため、既存の test-python / test-go / test-typescript / docker-build ジョブの挙動は変わらない。

---
_Generated by [Claude Code](https://claude.ai/code/session_013pmf3QgetYd3kRxrcXKxtv)_