### PR TITLE
docs: SUPPORT.md を追加してユーザーの問い合わせ導線を整理

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,28 @@
+# サポート
+
+pulseboard をご利用いただきありがとうございます。以下のチャネルで質問・報告を受け付けています。
+
+## バグ報告
+
+再現可能な不具合は Issue テンプレートに沿って報告してください。
+
+- [新規 Issue を作成](../../issues/new/choose)
+
+再現手順・期待する挙動・実際の挙動・関連サービス（analytics-api / api-gateway / health-checker など）・ログの抜粋を添えてください。
+
+## 機能リクエスト
+
+新機能や改善提案は Issue テンプレートの Feature request をご利用ください。
+
+## 質問・議論
+
+- 一般的な使い方の質問は [Discussions](../../discussions) を優先してください。
+- Discussions が無効な場合は、`question` ラベルを付けた Issue で受け付けます。
+
+## セキュリティに関する報告
+
+脆弱性は Issue には投稿せず、[SECURITY.md](../SECURITY.md) の手順に従って非公開で連絡してください。
+
+## 貢献したい方へ
+
+コードやドキュメントの貢献は歓迎します。事前に [CONTRIBUTING.md](../CONTRIBUTING.md) と [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) をご一読ください。


### PR DESCRIPTION
## 概要

`.github/SUPPORT.md` を新規追加し、ユーザーからの問い合わせ導線（バグ報告 / 機能リクエスト / 質問 / セキュリティ報告 / 貢献方法）を日本語で一元的に整理しました。

GitHub は `.github/SUPPORT.md` を自動的に認識し、新規 Issue 作成画面などから案内リンクを提示します。これにより、Issue には本来の不具合報告・機能提案が集約され、質問や脆弱性報告が適切なチャネル (Discussions / SECURITY.md) に誘導されやすくなります。

## 変更内容

- `.github/SUPPORT.md` を新規追加
  - バグ報告 → Issue テンプレート
  - 機能リクエスト → Issue の Feature request
  - 質問 → Discussions もしくは `question` ラベル
  - セキュリティ → `SECURITY.md`
  - 貢献 → `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md`

## 影響範囲

ドキュメント追加のみのため、アプリケーション動作への影響はありません。

Closes #157


---
_Generated by [Claude Code](https://claude.ai/code/session_011rwpu68p2Kg9zVsvD2S11K)_