### PR TITLE
chore: 各サービスに `.dockerignore` を追加してビルドコンテキストを削減

### DIFF
--- a/analytics-api/.dockerignore
+++ b/analytics-api/.dockerignore
@@ -1,0 +1,68 @@
+# analytics-api (Python / FastAPI) の Docker ビルドコンテキストから除外するファイル
+#
+# 目的:
+#   - ビルドコンテキスト送信を高速化する
+#   - テストファイル・開発用生成物・機密ファイルを最終イメージに含めない
+#   - キャッシュ効率を維持する（無関係な変更でキャッシュ無効化を防ぐ）
+
+# VCS / CI メタデータ
+.git
+.gitignore
+.gitattributes
+.github
+
+# ローカル環境変数（機密混入防止）
+.env
+.env.*
+!.env.example
+
+# エディタ / OS 生成物
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.eggs/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# 仮想環境
+.venv/
+venv/
+ENV/
+env/
+
+# 開発用依存 / テスト
+requirements-dev.txt
+test_*.py
+*_test.py
+tests/
+
+# ドキュメント（イメージには不要）
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+*.md
+
+# Docker 自体（自己参照防止）
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# ローカル生成物
+*.log

--- a/api-gateway/.dockerignore
+++ b/api-gateway/.dockerignore
@@ -1,0 +1,73 @@
+# api-gateway (TypeScript / Node.js / Express) の Docker ビルドコンテキストから除外するファイル
+#
+# 目的:
+#   - ビルドコンテキスト送信を高速化する
+#   - node_modules をローカルからコピーせず Dockerfile の `npm ci` に任せる
+#   - テストファイル・開発用生成物・機密ファイルを最終イメージに含めない
+
+# VCS / CI メタデータ
+.git
+.gitignore
+.gitattributes
+.github
+
+# ローカル環境変数（機密混入防止）
+.env
+.env.*
+!.env.example
+
+# エディタ / OS 生成物
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Node.js 依存 / ビルド生成物
+# node_modules はローカルの OS/Arch 依存バイナリを含む可能性があるため必ず除外し、
+# コンテナ内の `npm ci` でクリーンな状態から解決する。
+node_modules/
+dist/
+build/
+.npm/
+.node-gyp/
+
+# TypeScript / テスト / カバレッジ
+coverage/
+*.tsbuildinfo
+.jest-cache/
+*.test.ts
+*.test.js
+*.spec.ts
+*.spec.js
+src/**/*.test.ts
+src/**/*.spec.ts
+tests/
+__tests__/
+jest.config.js
+
+# ESLint / 開発用設定（ランタイムでは不要）
+.eslintrc*
+.eslintcache
+
+# ロックファイル以外の管理ツール（存在する場合）
+yarn.lock
+pnpm-lock.yaml
+
+# ドキュメント（イメージには不要）
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+*.md
+
+# Docker 自体（自己参照防止）
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# ローカル生成物
+*.log
+npm-debug.log*

--- a/health-checker/.dockerignore
+++ b/health-checker/.dockerignore
@@ -1,0 +1,57 @@
+# health-checker (Go) の Docker ビルドコンテキストから除外するファイル
+#
+# 目的:
+#   - ビルドコンテキスト送信を高速化する
+#   - テストファイル・開発用生成物・機密ファイルを最終イメージに含めない
+#   - Multi-stage ビルドの builder ステージでも不要ファイルを避ける
+
+# VCS / CI メタデータ
+.git
+.gitignore
+.gitattributes
+.github
+
+# ローカル環境変数（機密混入防止）
+.env
+.env.*
+!.env.example
+
+# エディタ / OS 生成物
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Go テストファイル / カバレッジ
+*_test.go
+testdata/
+*.out
+coverage.txt
+coverage.html
+
+# Go ビルド生成物
+/health-checker
+/bin/
+/dist/
+*.exe
+
+# ベンダリング（本リポジトリは vendor を使用していないため念のため除外）
+vendor/
+
+# ドキュメント（イメージには不要）
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+LICENSE
+SECURITY.md
+*.md
+
+# Docker 自体（自己参照防止）
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# ローカル生成物
+*.log


### PR DESCRIPTION
## 変更概要

- `analytics-api/.dockerignore` を新規追加 (Python 向け)
- `health-checker/.dockerignore` を新規追加 (Go 向け)
- `api-gateway/.dockerignore` を新規追加 (TypeScript/Node.js 向け)

## 除外対象（共通）

- VCS メタデータ: `.git`, `.gitignore`, `.gitattributes`, `.github`
- ローカル環境変数: `.env`, `.env.*` (ただし `.env.example` は例外的に含める)
- OS / エディタ生成物: `.DS_Store`, `.vscode/`, `.idea/`
- ドキュメント: `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`
- Docker 自体: `Dockerfile`, `.dockerignore`, `docker-compose*.yml`
- ローカルログ: `*.log`

## 言語ごとの追加除外

**analytics-api (Python)**:
- `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.mypy_cache/`
- `test_*.py`, `*_test.py`, `tests/`
- 仮想環境: `.venv/`, `venv/`
- カバレッジ生成物

**health-checker (Go)**:
- `*_test.go`, `testdata/`
- ビルド生成物: `/health-checker`, `/bin/`, `/dist/`
- vendor（本リポジトリは未使用だが念のため）

**api-gateway (TypeScript/Node.js)**:
- `node_modules/` (Dockerfile 内の `npm ci` で解決するため必須除外)
- `dist/`, `build/`, `*.tsbuildinfo`
- テスト: `*.test.ts`, `*.spec.ts`, `tests/`, `__tests__/`, `jest.config.js`
- ESLint 設定 / キャッシュ
- 他パッケージマネージャのロックファイル

## 対応 Issue

Closes #159

## 動作確認手順

1. `docker compose build` を実行し、全サービスのイメージがエラーなくビルドされることを確認
2. `docker compose up` で起動し、`http://localhost:8000/health` が `{"status":"healthy","service":"api-gateway"}` を返すことを確認
3. `docker image ls` でイメージサイズが従来より減少している（または同等以下）ことを確認
4. 既存 CI (`.github/workflows/ci.yml`) の `docker-build` ジョブが引き続きパスすることを確認

## 期待される効果

- **セキュリティ**: `.env` などのローカル機密ファイルがイメージへ混入するリスクを排除
- **サイズ削減**: テストファイル・キャッシュ・ドキュメントを最終イメージから除外
- **ビルド高速化**: ビルドコンテキスト送信サイズを削減
- **キャッシュ効率**: README や `.github/` 配下の変更で Docker レイヤーキャッシュが無効化されなくなる

## 注意事項

- Dockerfile 側の `COPY` は既存のパターンを維持しており、コード変更はありません
- `analytics-api` の `Dockerfile` は `COPY . .` を使うため `.dockerignore` の効果が特に大きい
- `api-gateway` は既に `COPY package*.json`、`COPY tsconfig.json`、`COPY src/` と選択的コピーだが、`.dockerignore` によりビルドコンテキスト自体が縮小する

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBZnRfqW2jFZguQ6CEJ7xD)_