### PR TITLE
chore(ci): ワークフローに最小権限の `permissions` ブロックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# ワークフロー全体のデフォルト権限を最小限 (contents: read) に制限する。
+# 各ジョブはリポジトリのチェックアウト以外に GITHUB_TOKEN を利用しないため、
+# 書き込み権限を持たせない。将来ジョブ単位で追加権限が必要になった場合は、
+# そのジョブに `permissions:` を上書き宣言する運用とする。
+# 参考: https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+permissions:
+  contents: read
+
 # 同一ワークフロー・同一 ref (PR ブランチや main) で新しいジョブが起動したら、
 # 進行中の古いジョブをキャンセルする。PR に短時間で連続 push した場合の
 # 実行枠・実行時間の無駄を削減する。


### PR DESCRIPTION
## 変更概要

`.github/workflows/ci.yml` に最小権限 (`contents: read`) の `permissions:` ブロックを追加し、`GITHUB_TOKEN` を least-privilege に固定する。

## 変更内容の詳細

- ワークフロー先頭で `permissions: contents: read` を宣言。全 4 ジョブ (`test-python`, `test-go`, `test-typescript`, `docker-build`) に一括適用。
- 現状のジョブはリポジトリのチェックアウトとテスト/ビルドのみで、リポジトリ書き込み・PR/Issue 操作・パッケージ操作を行わないため、`contents: read` で十分。
- 権限の意図と将来ジョブ単位で上書きする運用方針をコメントに残した。

## 対応 Issue

Closes #163

## 影響範囲

- [ ] `analytics-api/` (Python)
- [ ] `api-gateway/` (TypeScript)
- [ ] `health-checker/` (Go)
- [x] `.github/` (CI / メタデータ)
- [ ] `docker-compose.yml` / インフラ
- [ ] ドキュメントのみ

## 動作確認手順

1. ローカルで YAML の妥当性を確認:
   ```bash
   python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(d.get('permissions'))"
   # => {'contents': 'read'}
   ```
2. PR CI (`test-python` / `test-go` / `test-typescript` / `docker-build`) が緑になることを確認。既存ジョブはいずれもチェックアウト以外の書き込みを要さないため、`contents: read` のみでパスするはず。

## リスク・注意点

- なし。`actions/checkout@v4` は `contents: read` のみを要求するため、既存ジョブ動作は変わらない。
- 将来書き込み権限が必要なジョブが増える場合は、そのジョブに `permissions:` を上書きで追加する運用に切り替える。

## チェックリスト

- [x] `flake8` / `npm run lint` / `go vet` などの静的解析がローカルで緑（本 PR は `.github/workflows/ci.yml` の権限追加のみでソース変更なしのため対象外。CI で通ることを確認）
- [x] 該当するテスト (`pytest` / `npm test` / `go test`) がローカルで緑（同上・CI で確認）
- [x] 変更に応じたテストを追加した（またはその必要が無いことを本文で説明）: ワークフロー権限のメタデータ変更のためテスト追加不要
- [ ] README / ドキュメントを更新した（必要な場合）: ドキュメント影響なし
- [ ] 環境変数を追加・変更した場合、`.env.example` を更新した: 該当なし


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSfXMiHzvrKAGaL5dphK1B)_