### PR TITLE
fix(health-checker): `EXTRA_TARGETS` の URL スキームを検証して不正値を drop する

### DIFF
--- a/health-checker/extra_targets_test.go
+++ b/health-checker/extra_targets_test.go
@@ -65,6 +65,30 @@ func TestParseExtraTargets(t *testing.T) {
 			raw:     `{"name":"x","url":"http://x"}`,
 			wantErr: true,
 		},
+		{
+			// スキーム抜きの "localhost:8080/health" は url.Parse で
+			// Scheme="localhost" と解釈され http.Client.Get で失敗するため drop する。
+			name: "entry with scheme-less URL is skipped",
+			raw:  `[{"name":"redis","url":"localhost:6379/ping"},{"name":"ok","url":"http://ok"}]`,
+			want: []ServiceTarget{{Name: "ok", URL: "http://ok"}},
+		},
+		{
+			// tcp:// など http(s) 以外のスキームは net/http.Client が非対応のため drop する。
+			name: "entry with non-http scheme is skipped",
+			raw:  `[{"name":"db","url":"tcp://db:5432"},{"name":"ok","url":"https://ok"}]`,
+			want: []ServiceTarget{{Name: "ok", URL: "https://ok"}},
+		},
+		{
+			// "http://" はスキームがあっても Host が空でリクエスト先が定まらないため drop する。
+			name: "entry with empty host is skipped",
+			raw:  `[{"name":"broken","url":"http://"},{"name":"ok","url":"http://ok"}]`,
+			want: []ServiceTarget{{Name: "ok", URL: "http://ok"}},
+		},
+		{
+			name: "https scheme is accepted",
+			raw:  `[{"name":"prod","url":"https://prod.example.com/health"}]`,
+			want: []ServiceTarget{{Name: "prod", URL: "https://prod.example.com/health"}},
+		},
 	}
 
 	for _, tc := range cases {
@@ -226,5 +250,41 @@ func TestMergeExtraTargets(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("got[%d] = %+v, want %+v", i, got[i], want[i])
 		}
+	}
+}
+
+// isValidTargetURL は EXTRA_TARGETS 由来 URL が http.Client.Get 可能かを判定する。
+// 実運用で観測された誤設定パターン（スキーム抜き、非 http スキーム、ホスト抜き）
+// と受理すべき正常系（http / https、ポート・パス付き、IP アドレス）を網羅する。
+func TestIsValidTargetURL(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"http host", "http://ok", true},
+		{"https host", "https://ok.example.com", true},
+		{"http with port", "http://ok:8080", true},
+		{"https with path and query", "https://ok.example.com/health?verbose=1", true},
+		{"http ipv4", "http://127.0.0.1:8080/health", true},
+
+		{"empty string", "", false},
+		{"scheme-less host:port", "localhost:6379/ping", false},
+		{"bare host", "example.com/health", false},
+		{"tcp scheme", "tcp://db:5432", false},
+		{"ftp scheme", "ftp://files.example.com", false},
+		{"file scheme", "file:///etc/passwd", false},
+		{"scheme only, empty host", "http://", false},
+		{"https scheme only, empty host", "https://", false},
+		// url.Parse がスキームを小文字化するため "HTTP://" は "http://" 相当として受理される。
+		{"uppercase scheme is accepted (parser lowercases)", "HTTP://ok", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidTargetURL(tc.raw); got != tc.want {
+				t.Errorf("isValidTargetURL(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
 	}
 }

--- a/health-checker/main.go
+++ b/health-checker/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -241,12 +242,41 @@ func reportMetricWithPolicy(
 	return lastErr
 }
 
+// isValidTargetURL は EXTRA_TARGETS のエントリの URL が health-checker から
+// 実際に http.Client.Get() 可能な形式かを検証する。
+//
+// Go の net/http.Client は http / https スキームのみをサポートするため、
+// スキーム抜け（"localhost:8080/health"）や別スキーム（"tcp://…"）・
+// ホスト抜け（"http://"）を parseExtraTargets の時点で silent drop する。
+// 旧実装ではこれらも valid として登録され、毎チェックサイクルで
+// "unsupported protocol scheme" 相当のエラーが積み上がり、不達ターゲットの
+// "unhealthy" メトリクスが analytics-api に送り続けられていた。
+func isValidTargetURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	if u.Host == "" {
+		return false
+	}
+	return true
+}
+
 // parseExtraTargets は EXTRA_TARGETS 環境変数の値をパースし、追加ターゲットを返す。
 //
 // 期待する形式は JSON 配列で、各要素は `{"name":"","url":""}`。空文字列・
-// パース失敗・型ミスマッチ・name/url いずれかが空のエントリは無視し、
-// プロセスは常にデフォルトターゲットのみで起動できるように fail-open にする
-// （運用時に誤った JSON を渡してもコンテナが再起動ループしない）。
+// パース失敗・型ミスマッチ・name/url いずれかが空のエントリ・URL が http(s)
+// スキーム以外のエントリは無視し、プロセスは常にデフォルトターゲットのみで
+// 起動できるように fail-open にする（運用時に誤った JSON を渡してもコンテナが
+// 再起動ループしない）。
+//
+// URL 検証で弾いたエントリは silent drop ではなく `[WARN]` ログを出し、
+// mergeExtraTargets の name 衝突ドロップと同じ観測性ポリシーに揃える
+// （name/url が完全に空のエントリは明らかな typo/incomplete なので従来通り
+// 静かにスキップする）。
 //
 // 復帰値の第 2 引数はパースに失敗した場合のエラー。呼び元は警告ログのみに使い、
 // 起動可否の判定には使わない（設定ミス通知の観点で有用だが致命傷ではない）。
@@ -261,6 +291,13 @@ func parseExtraTargets(raw string) ([]ServiceTarget, error) {
 	valid := make([]ServiceTarget, 0, len(entries))
 	for _, e := range entries {
 		if e.Name == "" || e.URL == "" {
+			continue
+		}
+		if !isValidTargetURL(e.URL) {
+			log.Printf(
+				"[WARN] Ignoring EXTRA_TARGETS entry %q: invalid URL %q (must be http:// or https:// with a host)",
+				e.Name, e.URL,
+			)
 			continue
 		}
 		valid = append(valid, e)


### PR DESCRIPTION
## 概要

`health-checker/main.go` の `parseExtraTargets` は URL の形式検証を行っておらず、`"localhost:6379/ping"` のようなスキーム抜きの URL や `"tcp://…"` のような非 HTTP スキームがそのままターゲットに登録されていた。

Go の `net/http.Client` は http / https のみをサポートするため、こうしたエントリは毎チェックサイクルで `unsupported protocol scheme` 相当のエラーを発生させ、不達ターゲットの `unhealthy` メトリクスが analytics-api に送り続けられて監視ダッシュボードのノイズになっていた。

## 変更内容

- **`health-checker/main.go`**
  - `net/url` import を追加
  - `isValidTargetURL(raw string) bool` ヘルパーを追加 — `url.Parse` でパース可、`Scheme` が `http` / `https`、`Host` が非空であることを検証
  - `parseExtraTargets` から `isValidTargetURL` を呼び出し、失敗エントリを `[WARN]` ログ付きで drop
- **`health-checker/extra_targets_test.go`**
  - `TestParseExtraTargets` に不正 URL パターン 4 ケース (`scheme-less` / `tcp scheme` / `empty host` / `https accepted`) を追加
  - `TestIsValidTargetURL` を新規追加 — 受理 5 ケース・拒否 8 ケース・境界 1 ケース (uppercase scheme lowercased by `url.Parse`)

## 設計判断

- **fail-open を維持**: 不正 URL エントリは silent drop でなく `[WARN]` ログを出しつつスキップし、プロセスは常にデフォルトターゲット (analytics-api / api-gateway) で起動継続する。`mergeExtraTargets` の name 衝突ドロップと同じ観測性ポリシー。
- **`name`/`url` が完全に空のエントリは従来通り silent skip**: 明らかな typo/incomplete エントリで、警告を出すほどの情報価値がないため既存挙動を維持。
- **公開 API は非破壊**: `parseExtraTargets` のシグネチャ・戻り値の型は不変。既存 6 テストは変更なしでパス。

## 動作確認

```
$ cd health-checker && go vet ./... && go test -count=1 ./...
ok  github.com/mohadayo/pulseboard/health-checker  1.366s
```

新規テスト (`TestIsValidTargetURL`) 全 14 サブテスト、拡張された `TestParseExtraTargets` 全 13 サブテスト成功を確認済み。

Closes #165

---
_Generated by [Claude Code](https://claude.ai/code/session_014ohTAzXChc76grrR2zvVya)_