### PR TITLE
docs: README の API 一覧に未記載のエンドポイントを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,15 @@ npm start
 | GET | `/api/metrics` | List all metrics (proxy to Analytics API、`?q=` で service 名部分一致検索) |
 | GET | `/api/metrics/summary` | Per-service uptime and response time summary（`?q=` で service 名部分一致検索） |
 | GET | `/api/metrics/overview` | 全サービス横断のトップレベル稼働サマリ（proxy to Analytics API、`?q=` で部分一致検索） |
+| GET | `/api/metrics/count` | フィルタ後の件数・status 別件数・登場サービス数のみを返す軽量エンドポイント（`?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/api/metrics/services` | サービス一覧（`?q=` で部分一致検索、`?sort=` / `?order=` / `?limit=` / `?offset=`） |
 | GET | `/api/metrics/services/names` | distinct な service 名一覧のみを返す軽量エンドポイント（フィルタドロップダウン populate 用、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
+| GET | `/api/metrics/services/:name` | 単一サービスの詳細（`?since=` / `?until=`）。該当サービスが存在しなければ analytics-api の 404 をそのまま伝播 |
 | GET | `/api/metrics/timeseries` | 時系列バケット集計（`?bucket_seconds=` でバケット幅を指定、既定 60 秒） |
 | GET | `/api/metrics/uptime` | 全サービス横断の SLA 集約（uptime_pct / MTTR / 進行中インシデント。`?q=` / `?since=` / `?until=` / `?ongoing_only=` / `?limit=` / `?offset=` / `?order=`） |
 | POST | `/api/metrics` | Record a metric (proxy to Analytics API) |
+| POST | `/api/metrics/batch` | 複数メトリクスを 1 リクエストでまとめて記録（proxy to Analytics API `/metrics/batch`） |
+| DELETE | `/api/metrics` | サービス名 / 時刻を組合せて対象メトリクスを削除（`?service=` / `?before=` / `?status=`、少なくとも 1 つ指定必須） |
 | GET | `/api/check` | Run health checks on all targets (proxy to Checker) |
 | GET | `/api/status` | Aggregated health status of all internal services |
 
@@ -403,6 +407,7 @@ curl "http://localhost:8001/metrics/services/web/timeseries?bucket_seconds=300&s
 |--------|----------|-------------|
 | GET | `/health` | Health check |
 | GET | `/check` | Run health checks on all configured targets |
+| GET | `/targets` | 起動時に構築した監視対象一覧（`analytics-api` / `api-gateway` + `EXTRA_TARGETS` 由来）を JSON で返す。運用時に `ANALYTICS_URL` / `GATEWAY_URL` / `EXTRA_TARGETS` の反映状態を curl 一発で確認する用途 |
 | GET | `/config` | 実行中の設定値（間隔・タイムアウト・リトライ・analytics-api URL）を JSON で返す |
 
 **実行時設定の確認 (`GET /config`):**


### PR DESCRIPTION
## 概要

`README.md` の各サービス API 一覧表と実装 (`app.ts` / `main.go`) の間に乖離があり、テスト済み・実装済みのエンドポイントが README から発見できない状態だったので追記します。

Closes #167

## 変更内容

### API Gateway 表への追加 (4 行)

| Method | Endpoint | 実装場所 |
|--------|----------|---------|
| GET | `/api/metrics/count` | `api-gateway/src/app.ts` |
| GET | `/api/metrics/services/:name` | `api-gateway/src/app.ts`（service detail） |
| POST | `/api/metrics/batch` | `api-gateway/src/app.ts` |
| DELETE | `/api/metrics` | `api-gateway/src/app.ts` |

### Health Checker 表への追加 (1 行)

| Method | Endpoint | 実装場所 |
|--------|----------|---------|
| GET | `/targets` | `health-checker/main.go` (`makeTargetsHandler`) |

## 変更方針

- 既存の記述順序を維持（例: `/api/metrics/services/:name` は `/api/metrics/services/names` の後ろに配置 — Express のルート登録順に一致）
- 表への追加のみ。詳細説明ブロックの追加は行わない（別 PR での拡張余地を残す）
- コード変更・依存追加・CI 変更なし。README.md のみ

## 検証

ローカルで以下を実行して構文と描画を確認済み:

- 各テーブルの列数一致チェック (Python スクリプト) → OK
- `python -m markdown README.md` で HTML 描画 → 26KB 相当、追加した 5 エンドポイントすべてが HTML に含まれることを確認

## CI 影響

ドキュメンテーションのみの変更のため、既存の 4 ジョブ (`test-python` / `test-go` / `test-typescript` / `docker-build`) はいずれも変更なしで通過するはずです。

---
_Generated by [Claude Code](https://claude.ai/code/session_013rumWXtoGobkx15Gga3tsb)_