### PR TITLE
test(analytics-api): /metrics/count で q パラメータが上限超過のとき 400 を返すテストを追加

### DIFF
--- a/analytics-api/test_count_q_validation.py
+++ b/analytics-api/test_count_q_validation.py
@@ -1,0 +1,32 @@
+"""`/metrics/count` エンドポイントの `q` クエリパラメータのバリデーション回帰テスト。
+
+`_normalize_q_param()` は `q` が `MAX_SERVICE_LENGTH = 100` 文字を超えると 400 を
+返す共通バリデータだが、`test_main.py` では `/metrics` / `/metrics/summary` /
+`/metrics/overview` の 3 エンドポイントでのみ「q が長すぎる」ケースを回帰していた。
+
+`/metrics/count` は `_normalize_q_param()` を経由しているものの、長さ超過時の
+レスポンス契約を回帰していなかったため、将来リファクタで誤って共通バリデータの
+呼び出しが外された場合に検知できない。本ファイルはその 1 ケースの回帰専用。
+
+`test_main.py` に直接追記しなかったのは、既存ファイルが大きく、単一エンドポイントの
+追加テストを分離しておいたほうが差分レビューが読みやすくなるため。既存の
+`test_count_blank_q_returns_400`（`test_main.py`）と対になる位置づけ。
+"""
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_count_q_too_long_rejected():
+    """`q` が MAX_SERVICE_LENGTH (100) を超えると 400 と `detail` に "100" を含む。
+
+    既存 `test_list_metrics_q_too_long_returns_400`（`/metrics` に対する同種の
+    検査）と同じ入力・同じアサーションで、`/metrics/count` に対して契約を固定する。
+    """
+    long_q = "x" * 101  # MAX_SERVICE_LENGTH = 100
+    resp = client.get(f"/metrics/count?q={long_q}")
+    assert resp.status_code == 400
+    assert "100" in resp.json()["detail"]


### PR DESCRIPTION
## 変更概要

- `analytics-api/test_count_q_validation.py` を新設
- `/metrics/count` に `?q=x * 101` を渡すと 400 と `detail` に `"100"` を含む契約を回帰
- `_normalize_q_param()` は 9 エンドポイントから呼ばれているが、q 上限超過テストは既存 3 エンドポイント（`/metrics` / `/summary` / `/overview`）でしか行われていなかったギャップを埋める

## 関連 Issue

Closes #169

## 動作確認手順

1. `cd analytics-api`
2. `pip install -r requirements-dev.txt`
3. `flake8 --max-line-length=120 --exclude=__pycache__ .`
4. `pytest test_count_q_validation.py -v`
5. すべてのテストが緑になることを確認

## 補足

- 既存 `test_main.py` に直接追記しなかった理由: 同ファイルが 3,800 行超と大きく、単一エンドポイントの追加テストを分離しておいたほうが差分レビューが読みやすくなるため
- 既存プロダクションコード・既存テストへは一切変更を加えていません（純増）
- 命名・アサーションは既存 `test_list_metrics_q_too_long_returns_400` と対称

---
_Generated by [Claude Code](https://claude.ai/code/session_018ECraachnX29aoqMYweRCQ)_