### PR TITLE
chore(api-gateway): Dockerfile をマルチステージビルド化して本番イメージを最小化

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,14 +1,45 @@
-FROM node:22-alpine
+# syntax=docker/dockerfile:1
+
+# ---------- Stage 1: builder ----------
+# devDependencies (typescript / ts-node / eslint / jest 等) を含めて全依存を install し、
+# TypeScript を dist/ にコンパイルする。この layer は最終イメージには含めない。
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
+# package.json / package-lock.json をコピーして npm ci でロックファイル通り install
 COPY package*.json ./
 RUN npm ci
 
+# ビルドに必要なソースと tsconfig をコピー
 COPY tsconfig.json ./
 COPY src/ ./src/
 
+# TypeScript を dist/ にビルド
 RUN npm run build
+
+# ---------- Stage 2: runtime ----------
+# 本番実行に必要な production 依存のみを install し、builder からコンパイル済みの
+# dist/ をコピーする。TypeScript ソースや devDependencies は最終イメージに含めない。
+FROM node:22-alpine AS runtime
+
+# express / winston などが production 経路 (キャッシュ / 最適化) を使うようにする
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+# production 依存のみを install (devDependencies を除外)。
+# --no-audit --no-fund で CI 中の余計な出力とネットワーク I/O を減らし、
+# npm cache も削除してイメージサイズを最小化する。
+COPY package*.json ./
+RUN npm ci --omit=dev --no-audit --no-fund && npm cache clean --force
+
+# builder からビルド成果物のみをコピー
+COPY --from=builder /app/dist ./dist
+
+# node:22-alpine にプリセットされている非 root ユーザで実行し、
+# コンテナランタイム上での特権を最小化する
+USER node
 
 EXPOSE 8000
 


### PR DESCRIPTION
## 変更概要

- `api-gateway/Dockerfile` をシングルステージからマルチステージ (builder / runtime) 構成へ書き換え
- **builder ステージ**: `node:22-alpine` で `npm ci` により devDependencies を含めて全依存を install し、`npm run build` で `dist/` を生成
- **runtime ステージ**: `node:22-alpine` で `npm ci --omit=dev --no-audit --no-fund` により production 依存のみ install、`npm cache clean --force` でキャッシュを削除し、builder から `dist/` だけをコピー
- runtime ステージで `ENV NODE_ENV=production` を設定し、express / winston などが production 経路を通るようにする
- runtime ステージで `USER node` に切替え、`node:22-alpine` にプリセットされている非 root ユーザで起動する
- `WORKDIR /app` / `EXPOSE 8000` / `CMD ["node", "dist/index.js"]` は据え置きで、`docker-compose.yml` (`build: ./api-gateway`) と CI (`.github/workflows/ci.yml` の `docker compose build`) の呼び出し面は変更しない

## 効果

- 本番イメージから `typescript` / `ts-node` / `ts-jest` / `jest` / `eslint` / `@typescript-eslint/*` / `supertest` などの devDependencies が消え、イメージサイズが縮小する
- 本番イメージから TypeScript ソース (テストコード `app.test.ts` を含む) と `tsconfig.json` が消え、コンテナ内での不要なファイル露出を抑える
- 非 root 実行によりコンテナランタイム上での特権が減る

Closes #173

## 動作確認手順

1. ローカルで `docker compose build api-gateway` が成功することを確認する
2. `docker compose up -d` で起動し、`docker compose ps` で `api-gateway` が healthy になることを確認する (`docker-compose.yml` のヘルスチェック `wget -q --spider http://localhost:8000/health` が非 root ユーザ `node` からも動作する)
3. `curl http://localhost:8000/health` で `200 OK` が返ることを確認する
4. `docker image ls pulseboard-api-gateway` でイメージサイズが変更前より縮小していることを確認する
5. `docker run --rm --entrypoint sh pulseboard-api-gateway -c 'ls /app'` で `dist` と `node_modules` / `package*.json` のみが存在し、`src/` や `tsconfig.json` が含まれないことを確認する
6. GitHub Actions CI (`test-typescript` および `docker-build` ジョブ) がグリーンになることを確認する

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEjNVRJfbcuKQaod7RSL7Z)_