### PR TITLE
docs: README 冒頭に目次 (Table of Contents) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Service health monitoring and analytics platform built with a polyglot microservice architecture using Python, Go, and TypeScript.
 
+## 目次
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Quick Start](#quick-start)
+  - [Prerequisites](#prerequisites)
+  - [Using Docker Compose](#using-docker-compose)
+  - [Manual Setup](#manual-setup)
+- [API Reference](#api-reference)
+  - [API Gateway (port 8000)](#api-gateway-port-8000)
+  - [Analytics API (port 8001)](#analytics-api-port-8001)
+  - [Health Checker (port 8002)](#health-checker-port-8002)
+- [Configuration](#configuration)
+- [Testing](#testing)
+- [CI/CD](#cicd)
+- [Project Structure](#project-structure)
+- [License](#license)
+
 ## Overview
 
 PulseBoard collects health check metrics from monitored services, analyzes uptime and response time trends, and provides a unified API gateway for accessing all monitoring data.


### PR DESCRIPTION
## 変更概要

- 24KB を超える `README.md` に目次が無く、GitHub 上で読者が目的のセクションに到達しづらかった。Overview の直前に `## 目次` セクションを新設し、主要な `##` 見出しおよび Quick Start / API Reference 配下の `###` 見出しへのアンカーリンクを列挙する。

## 変更内容の詳細

- `README.md` 冒頭のリード文と `## Overview` の間に、以下 15 リンクを含む目次を追加
  - `##` 見出し 9 件: Overview / Architecture / Quick Start / API Reference / Configuration / Testing / CI/CD / Project Structure / License
  - Quick Start 配下の `###` 3 件: Prerequisites / Using Docker Compose / Manual Setup
  - API Reference 配下の `###` 3 件: API Gateway (port 8000) / Analytics API (port 8001) / Health Checker (port 8002)
- 本文の内容変更・再構成・翻訳は行わない (目次追加のみ)
- 見出しの ID 埋め込み (`<a id="...">`) は行わず、GitHub 標準の slug 自動生成に依拠 (例: `## CI/CD` → `#cicd`、`## 目次` → `#目次`)

## 対応 Issue

Closes #175

## 影響範囲

- [ ] `analytics-api/` (Python)
- [ ] `api-gateway/` (TypeScript)
- [ ] `health-checker/` (Go)
- [ ] `.github/` (CI / メタデータ)
- [ ] `docker-compose.yml` / インフラ
- [x] ドキュメントのみ

## 動作確認手順

1. GitHub PR プレビュー (Files changed → Rich diff、または本ブランチの README を GitHub 上で表示) で `## 目次` セクションが Overview の直前に描画されることを確認する。
2. 目次の各リンクをクリックし、それぞれ以下のセクションにジャンプすることを確認する:
   - Overview / Architecture / Quick Start / Prerequisites / Using Docker Compose / Manual Setup
   - API Reference / API Gateway (port 8000) / Analytics API (port 8001) / Health Checker (port 8002)
   - Configuration / Testing / CI/CD / Project Structure / License
3. 目次より下 (Overview 以降) の本文が変更前と同一であることを diff で確認する。

## リスク・注意点

- ドキュメントのみの変更のため、CI (flake8 / pytest / go vet / go test / eslint / jest / docker compose build) の挙動に影響しない。
- 将来 README に新しい `##` セクションを追加する際は、目次への追記もあわせて行う運用が望ましい (PR レビュー観点として本 PR で明示化)。

## チェックリスト

- [x] `flake8` / `npm run lint` / `go vet` などの静的解析がローカルで緑 (ドキュメントのみ変更のため実行不要)
- [x] 該当するテスト (`pytest` / `npm test` / `go test`) がローカルで緑 (ドキュメントのみ変更のため実行不要)
- [x] 変更に応じたテストを追加した（またはその必要が無いことを本文で説明）— ドキュメント追加のためテスト不要
- [x] README / ドキュメントを更新した（必要な場合）— 本 PR 自体が README 更新
- [x] 環境変数を追加・変更した場合、`.env.example` を更新した — 環境変数の変更なし

---
_Generated by [Claude Code](https://claude.ai/code/session_015Qtv6522KE8pb75rrL2oTJ)_