### PR TITLE
docs: README の Analytics API 表に未掲載の 9 エンドポイントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,17 @@ Response:
 | GET | `/metrics/services/names` | distinct な service 名のみを返す軽量エンドポイント（per-service 集計を行わずペイロード最小化、`?q=` / `?since=` / `?until=` / `?order=` / `?limit=` / `?offset=`） |
 | GET | `/metrics/count` | フィルタ後のレコード件数・status 別件数・登場サービス数のみを返す軽量エンドポイント（`?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
 | GET | `/metrics/timeseries` | フィルタ後のレコードを `bucket_seconds` 秒幅の時系列バケットに集約（`?bucket_seconds=` / `?service=` / `?status=` / `?since=` / `?until=` / `?q=`） |
+| GET | `/metrics/services/{service_name}` | 単一サービスの詳細集計（`total_checks` / `healthy_checks` / `uptime_pct` / percentile / `latest_*` を 1 レスポンスに集約、`?since=` / `?until=`）。該当サービスが存在しなければ 404 |
 | GET | `/metrics/services/{service_name}/timeseries` | 単一サービスに絞った時系列バケット集計（`?bucket_seconds=` / `?status=` / `?since=` / `?until=`）。該当サービスが存在しなければ 404 |
 | GET | `/metrics/services/{service_name}/latest` | 単一サービスの直近 1 件の observation を `{service, status, response_time_ms, timestamp}` 形で返す軽量エンドポイント（`?since=` / `?until=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/recent` | 単一サービスの直近 N 件の observation を `timestamp` 降順で返す（集計なし。`?limit=` 1〜200 / `?since=` / `?until=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/status_changes` | 単一サービスのステータス遷移イベントを時系列順に返す（`?since=` / `?until=` / `?limit=` / `?offset=` / `?order=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/by_status` | 単一サービスの観測を `status` 別にグルーピングし、status ごとの count / avg / min / max / p50 / p95 / p99 / first_seen / last_seen を返す（`?since=` / `?until=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/by_hour_of_day` | 単一サービスの観測を「1 日のうちの時刻 (UTC 00〜23)」でグルーピングして返す（`?since=` / `?until=`）。populated バケットのみ返却。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/incidents` | 単一サービスの unhealthy インシデント一覧（開始・終了・duration・ongoing フラグ、`?since=` / `?until=` / `?limit=` / `?offset=` / `?order=` / `?min_duration_seconds=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/services/{service_name}/uptime` | 単一サービスの SLA 集約（`uptime_pct` に加え `incident_count` / `total_incident_seconds` / `longest_incident_seconds` / `mean_incident_seconds` / `ongoing_incident`、`?since=` / `?until=`）。該当サービスが存在しなければ 404 |
+| GET | `/metrics/incidents` | 全サービス横断のインシデント一覧（`?service=` / `?q=` / `?since=` / `?until=` / `?ongoing_only=` / `?limit=` / `?offset=` / `?order=` / `?min_duration_seconds=`） |
+| GET | `/metrics/uptime` | 全サービス横断の SLA 集約（`uptime_pct` / MTTR / 進行中インシデント。`?q=` / `?since=` / `?until=` / `?ongoing_only=` / `?limit=` / `?offset=` / `?order=`） |
 
 #### Delete Metrics
 


### PR DESCRIPTION
## 変更概要

`README.md` の `### Analytics API (port 8001)` セクションの API リファレンス表に、`analytics-api/main.py` で実装済みだが記載が欠落していた以下 9 エンドポイントを追記しました。

- `/metrics/services/{service_name}` — 単一サービスの詳細集計
- `/metrics/services/{service_name}/recent` — 単一サービスの直近 N 件 observation
- `/metrics/services/{service_name}/status_changes` — ステータス遷移イベント一覧
- `/metrics/services/{service_name}/by_status` — status 別レスポンス時間統計
- `/metrics/services/{service_name}/by_hour_of_day` — 時刻軸グルーピング
- `/metrics/services/{service_name}/incidents` — 単一サービス unhealthy インシデント一覧
- `/metrics/services/{service_name}/uptime` — 単一サービス SLA 集約
- `/metrics/incidents` — 全サービス横断インシデント一覧
- `/metrics/uptime` — 全サービス横断 SLA 集約

順序は `main.py` の実装順に合わせ、既存行のスタイル・パラメータ表記に揃えています。コード変更は一切ありません。

## 対応 Issue

Closes #177

## 動作確認手順

1. ローカルで `.venv/bin/flake8 --max-line-length=120 --exclude=__pycache__ main.py` → クリーン
2. `.venv/bin/pytest -q` → 323 passed（baseline と同一）
3. Markdown 表構造・パイプ整形を目視確認
4. 各エンドポイントが `analytics-api/main.py` に実際に存在することを `grep -n "^@app\." main.py` で相互確認済み

## リスク・注意

- ドキュメントのみの変更で、Python / Go / TypeScript / docker compose build いずれの CI ジョブにも影響しない
- 既存の `list_pull_requests` 応答にある open PR (#124 `.editorconfig`, #108 `dependabot`, #114 `by_month`/`by_day_of_week` docs) とはファイルレベルで競合しない（README のみ）

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmK5ieXXXFChCWQomhg6UN)_