### PR TITLE
feat(api-gateway): 基本セキュリティレスポンスヘッダを付与し x-powered-by を無効化 (#181)

### DIFF
--- a/api-gateway/src/app.test.ts
+++ b/api-gateway/src/app.test.ts
@@ -12,6 +12,28 @@ describe("API Gateway", () => {
     });
   });
 
+  describe("security response headers", () => {
+    // フレームワーク版数を漏らさない・MIME sniffing / clickjacking / referrer 漏洩を
+    // 抑止する最小限のヘッダが常時付与されていることを固定する。
+    it("adds nosniff / DENY / no-referrer and omits x-powered-by on 200", async () => {
+      const res = await request(app).get("/health");
+      expect(res.status).toBe(200);
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+      expect(res.headers["x-frame-options"]).toBe("DENY");
+      expect(res.headers["referrer-policy"]).toBe("no-referrer");
+      expect(res.headers["x-powered-by"]).toBeUndefined();
+    });
+
+    it("adds the same security headers to 404 responses", async () => {
+      const res = await request(app).get("/definitely-not-a-route");
+      expect(res.status).toBe(404);
+      expect(res.headers["x-content-type-options"]).toBe("nosniff");
+      expect(res.headers["x-frame-options"]).toBe("DENY");
+      expect(res.headers["referrer-policy"]).toBe("no-referrer");
+      expect(res.headers["x-powered-by"]).toBeUndefined();
+    });
+  });
+
   describe("GET /api/metrics", () => {
     it("returns 502 when analytics is down", async () => {
       const res = await request(app).get("/api/metrics");

--- a/api-gateway/src/app.ts
+++ b/api-gateway/src/app.ts
@@ -23,6 +23,29 @@ const STATUS_PROBE_TIMEOUT = parseInt(process.env.STATUS_PROBE_TIMEOUT || "3000"
 const MAX_REQUEST_BODY = process.env.MAX_REQUEST_BODY || "256kb";
 
 const app = express();
+
+// フレームワーク情報を露出しない。Express は既定で `X-Powered-By: Express`
+// を返すが、これは攻撃者に既知脆弱性版を探す手がかりを与えるだけで、
+// クライアントに機能上のメリットは無い。
+app.disable("x-powered-by");
+
+// すべての応答に最小限のセキュリティヘッダを付与する。
+// `helmet` を導入せず素の middleware で完結させることで依存を増やさない。
+//
+// - `X-Content-Type-Options: nosniff`: JSON エンドポイントを別 MIME として
+//   解釈させる MIME sniffing 攻撃を抑止。ブラウザから直接叩かれた場合や、
+//   拡張ツール経由でのアクセス時にも一貫して JSON として扱われる。
+// - `X-Frame-Options: DENY`: 本 API を `<iframe>` に埋め込ませない。JSON API は
+//   フレーム表示を意図しないため常時拒否 (クリックジャッキング対策)。
+// - `Referrer-Policy: no-referrer`: 内部 URL やクエリ文字列がリンク先の
+//   Referrer ヘッダとして外部に漏れないよう抑止。
+app.use((_req: Request, res: Response, next: NextFunction) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "no-referrer");
+  next();
+});
+
 app.use(express.json({ limit: MAX_REQUEST_BODY }));
 
 // アクセスログ。リクエスト着信時ではなく、応答完了 (res 'finish') の時点で


### PR DESCRIPTION
## 変更概要

- `app.disable("x-powered-by")` で Express の版数露出を停止
- 全応答に付与する 3 ヘッダの middleware を追加:
  - `X-Content-Type-Options: nosniff` — MIME sniffing 抑止
  - `X-Frame-Options: DENY` — JSON API のフレーム表示禁止 (clickjacking 対策)
  - `Referrer-Policy: no-referrer` — 内部 URL/クエリの Referrer 漏洩抑止
- `app.test.ts` に上記 4 点 (3 ヘッダ + `X-Powered-By` の非露出) を `/health` (200) と 404 応答の両方で検証するテストを追加
- 外部依存 (`helmet` 等) は追加しない

## 対応 Issue

Closes #181

## 動作確認

ローカルで CI 相当のチェックを実行済み:

- `npm ci` — OK
- `npm run lint` — OK
- `npm test` — 87 tests passed (既存 85 + 追加 2)

## 影響範囲

- `api-gateway/src/app.ts` の middleware 追加のみ。プロキシルーティング・エラーハンドラ・タイムアウト設定・分析 API/ヘルスチェッカへの契約に変更なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAoySsXLLMQfako2rSkm8T)_